### PR TITLE
add recursive multi-module analysis, external-only flow filtering, an…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdxgen/cdxgen-plugins-bin",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "Apache-2.0"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/darwin-amd64/package.json
+++ b/packages/darwin-amd64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-darwin-amd64",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Arm64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-darwin-arm64",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Arm64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/linux-amd64/package.json
+++ b/packages/linux-amd64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linux-amd64",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "linux amd64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/linux-arm/package.json
+++ b/packages/linux-arm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linux-arm",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Arm binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/linux-arm64/package.json
+++ b/packages/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linux-arm64",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Arm64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/linux-riscv64/package.json
+++ b/packages/linux-riscv64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linux-riscv64",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "RISC-V 64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/linuxmusl-amd64/package.json
+++ b/packages/linuxmusl-amd64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linuxmusl-amd64",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Linux musl amd64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/linuxmusl-arm64/package.json
+++ b/packages/linuxmusl-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linuxmusl-arm64",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Linux musl arm64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/ppc64/package.json
+++ b/packages/ppc64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linux-ppc64",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "ppc64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/windows-amd64/package.json
+++ b/packages/windows-amd64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-windows-amd64",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Windows amd64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/windows-arm64/package.json
+++ b/packages/windows-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-windows-arm64",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Arm64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/thirdparty/golem/JSON_ATTRIBUTE_REFERENCE.md
+++ b/thirdparty/golem/JSON_ATTRIBUTE_REFERENCE.md
@@ -8,51 +8,51 @@ The canonical schema lives in `internal/model/model.go`.
 
 Golem always emits a report envelope and core source evidence. Call graph and data-flow sections are optional. Crypto evidence is always collected from parsed source and type information.
 
-| Invocation option | Allowed values | JSON sections affected | What changes in output |
-| --- | --- | --- | --- |
-| `--callgraph` | `none`, `static`, `cha`, `rta`, `vta` | `callGraph`, `stats.callGraph*` | When not `none`, `callGraph` contains graph nodes, edges, diagnostics, and stats. |
-| `--dataflow` | `none`, `security`, `crypto`, `all` | `dataFlow`, `stats.dataFlow*` | When not `none`, `dataFlow` contains taint slices, nodes, edges, summaries, diagnostics, and stats. |
-| `--dataflow-callgraph` | `none`, `static`, `cha`, `rta`, `vta` | `dataFlow.diagnostics`, slice quality | Controls dynamic summary replay for data-flow interprocedural propagation. |
-| `--dataflow-pattern-packs` | `all`, `base`, `http`, `frameworks`, `data`, `filesystem`, `process`, `crypto`, `native`, `config`, `cloud` | `dataFlow.patterns` and downstream slices | Changes which sources, sinks, passthroughs, and sanitizers can match. |
-| `--include-stdlib` | boolean | `callGraph`, `dataFlow`, core usages | Includes standard library nodes/usages when enabled. |
-| `--include-local` | boolean | `callGraph`, `dataFlow`, core usages | Controls whether local module symbols are included. |
-| `--include-all-flows` | boolean | `callGraph`, `dataFlow` | When false, external-only module-cache flows are filtered out. |
+| Invocation option          | Allowed values                                                                                              | JSON sections affected                    | What changes in output                                                                              |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `--callgraph`              | `none`, `static`, `cha`, `rta`, `vta`                                                                       | `callGraph`, `stats.callGraph*`           | When not `none`, `callGraph` contains graph nodes, edges, diagnostics, and stats.                   |
+| `--dataflow`               | `none`, `security`, `crypto`, `all`                                                                         | `dataFlow`, `stats.dataFlow*`             | When not `none`, `dataFlow` contains taint slices, nodes, edges, summaries, diagnostics, and stats. |
+| `--dataflow-callgraph`     | `none`, `static`, `cha`, `rta`, `vta`                                                                       | `dataFlow.diagnostics`, slice quality     | Controls dynamic summary replay for data-flow interprocedural propagation.                          |
+| `--dataflow-pattern-packs` | `all`, `base`, `http`, `frameworks`, `data`, `filesystem`, `process`, `crypto`, `native`, `config`, `cloud` | `dataFlow.patterns` and downstream slices | Changes which sources, sinks, passthroughs, and sanitizers can match.                               |
+| `--include-stdlib`         | boolean                                                                                                     | `callGraph`, `dataFlow`, core usages      | Includes standard library nodes/usages when enabled.                                                |
+| `--include-local`          | boolean                                                                                                     | `callGraph`, `dataFlow`, core usages      | Controls whether local module symbols are included.                                                 |
+| `--include-all-flows`      | boolean                                                                                                     | `callGraph`, `dataFlow`                   | When false, external-only module-cache flows are filtered out.                                      |
 
 ## Report envelope
 
 The top-level `Report` carries metadata plus optional analysis sections.
 
-| JSON path | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `schemaVersion` | string | Versioned schema URL for compatibility checks. | Contract gating in ingestion pipelines. |
-| `tool.name` | string | Producer tool name. | Multi-tool provenance in merged evidence. |
-| `tool.version` | string | Producer version string. | Drift analysis and reproducibility. |
-| `runtime.*` | object | Host/runtime context used during analysis. | Explain platform-specific evidence differences. |
-| `options.*` | object | Effective analysis options persisted in report. | Auditing and replay of analysis behavior. |
-| `packages`, `files`, `imports`, `declarations`, `usages` | arrays | Core source and symbol evidence. | Occurrence evidence and code ownership mapping. |
-| `securitySignals` | array | Security API pattern observations. | Lightweight risk surfacing before taint review. |
-| `crypto` | object, optional | Crypto-focused evidence extracted from source. | CBOM-like enrichment and crypto policy checks. |
-| `callGraph` | object, optional | Call graph section when enabled. | Reachability and blast radius analysis. |
-| `dataFlow` | object, optional | Data-flow section when enabled. | Source-to-sink triage and exploitability review. |
-| `diagnostics` | array | Global diagnostic messages. | Handling partial analysis gracefully. |
-| `stats` | object | Aggregate counters across evidence sections. | Dashboards, trend baselining, quality checks. |
+| JSON path                                                | Type             | Purpose                                         | Typical use case                                 |
+| -------------------------------------------------------- | ---------------- | ----------------------------------------------- | ------------------------------------------------ |
+| `schemaVersion`                                          | string           | Versioned schema URL for compatibility checks.  | Contract gating in ingestion pipelines.          |
+| `tool.name`                                              | string           | Producer tool name.                             | Multi-tool provenance in merged evidence.        |
+| `tool.version`                                           | string           | Producer version string.                        | Drift analysis and reproducibility.              |
+| `runtime.*`                                              | object           | Host/runtime context used during analysis.      | Explain platform-specific evidence differences.  |
+| `options.*`                                              | object           | Effective analysis options persisted in report. | Auditing and replay of analysis behavior.        |
+| `packages`, `files`, `imports`, `declarations`, `usages` | arrays           | Core source and symbol evidence.                | Occurrence evidence and code ownership mapping.  |
+| `securitySignals`                                        | array            | Security API pattern observations.              | Lightweight risk surfacing before taint review.  |
+| `crypto`                                                 | object, optional | Crypto-focused evidence extracted from source.  | CBOM-like enrichment and crypto policy checks.   |
+| `callGraph`                                              | object, optional | Call graph section when enabled.                | Reachability and blast radius analysis.          |
+| `dataFlow`                                               | object, optional | Data-flow section when enabled.                 | Source-to-sink triage and exploitability review. |
+| `diagnostics`                                            | array            | Global diagnostic messages.                     | Handling partial analysis gracefully.            |
+| `stats`                                                  | object           | Aggregate counters across evidence sections.    | Dashboards, trend baselining, quality checks.    |
 
 ## `options` object details
 
 `options` is useful when reports are stored long-term and reviewed out of band.
 
-| JSON path | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `options.directory` | string | Absolute analysis root used by Golem. | Correlate evidence paths to source checkout. |
-| `options.patterns[]` | string | `go/packages` patterns analyzed. | Explain missing packages due to narrowed scope. |
-| `options.buildTags[]` | string | Build tags applied at load time. | Compare prod versus test build surfaces. |
-| `options.tests` | boolean | Test variants included or not. | Separate runtime evidence from test-only evidence. |
-| `options.noRecurse` | boolean | Recursive module discovery disabled flag. | Multi-module repository behavior auditing. |
-| `options.includeAllFlows` | boolean | External-only flow filtering control. | Keep or suppress third-party-only call/flow paths. |
-| `options.callGraphMode` | string | Effective call graph mode. | Precision versus performance tuning. |
-| `options.dataFlowMode` | string | Effective data-flow mode. | Security-only or broad taint modeling. |
-| `options.dataFlowCallGraphMode` | string | Dynamic summary replay mode for data-flow. | Improve interprocedural coverage in large codebases. |
-| `options.dataFlowPacks[]` | string | Active pattern packs. | Validate expected source and sink coverage. |
+| JSON path                       | Type    | Purpose                                    | Typical use case                                     |
+| ------------------------------- | ------- | ------------------------------------------ | ---------------------------------------------------- |
+| `options.directory`             | string  | Absolute analysis root used by Golem.      | Correlate evidence paths to source checkout.         |
+| `options.patterns[]`            | string  | `go/packages` patterns analyzed.           | Explain missing packages due to narrowed scope.      |
+| `options.buildTags[]`           | string  | Build tags applied at load time.           | Compare prod versus test build surfaces.             |
+| `options.tests`                 | boolean | Test variants included or not.             | Separate runtime evidence from test-only evidence.   |
+| `options.noRecurse`             | boolean | Recursive module discovery disabled flag.  | Multi-module repository behavior auditing.           |
+| `options.includeAllFlows`       | boolean | External-only flow filtering control.      | Keep or suppress third-party-only call/flow paths.   |
+| `options.callGraphMode`         | string  | Effective call graph mode.                 | Precision versus performance tuning.                 |
+| `options.dataFlowMode`          | string  | Effective data-flow mode.                  | Security-only or broad taint modeling.               |
+| `options.dataFlowCallGraphMode` | string  | Dynamic summary replay mode for data-flow. | Improve interprocedural coverage in large codebases. |
+| `options.dataFlowPacks[]`       | string  | Active pattern packs.                      | Validate expected source and sink coverage.          |
 
 ## Call graph JSON reference
 
@@ -60,53 +60,53 @@ The `callGraph` section exists only when `--callgraph` is not `none`.
 
 ### `callGraph` section
 
-| JSON path | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `callGraph.mode` | string | Requested mode. | Verify requested algorithm path. |
-| `callGraph.algorithm` | string | Effective algorithm used internally. | Debug mode coercions or fallback behavior. |
-| `callGraph.nodes[]` | array of `CallGraphNode` | Function-level graph vertices. | API fan-in and fan-out exploration. |
-| `callGraph.edges[]` | array of `CallGraphEdge` | Caller to callee relations. | Reachability and impact tracing. |
-| `callGraph.diagnostics[]` | array | Call graph construction issues. | Explain graph sparsity or unsupported shapes. |
-| `callGraph.stats.nodeCount` | integer | Number of graph nodes emitted. | Sanity checks and trend monitoring. |
-| `callGraph.stats.edgeCount` | integer | Number of graph edges emitted. | Graph density checks over time. |
+| JSON path                   | Type                     | Purpose                              | Typical use case                              |
+| --------------------------- | ------------------------ | ------------------------------------ | --------------------------------------------- |
+| `callGraph.mode`            | string                   | Requested mode.                      | Verify requested algorithm path.              |
+| `callGraph.algorithm`       | string                   | Effective algorithm used internally. | Debug mode coercions or fallback behavior.    |
+| `callGraph.nodes[]`         | array of `CallGraphNode` | Function-level graph vertices.       | API fan-in and fan-out exploration.           |
+| `callGraph.edges[]`         | array of `CallGraphEdge` | Caller to callee relations.          | Reachability and impact tracing.              |
+| `callGraph.diagnostics[]`   | array                    | Call graph construction issues.      | Explain graph sparsity or unsupported shapes. |
+| `callGraph.stats.nodeCount` | integer                  | Number of graph nodes emitted.       | Sanity checks and trend monitoring.           |
+| `callGraph.stats.edgeCount` | integer                  | Number of graph edges emitted.       | Graph density checks over time.               |
 
 ### `callGraph.nodes[]` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `id` | string | Stable node id, generally SSA function identity. | Join key for edge processing. |
-| `name` | string | Function short name. | Human-readable graph labels. |
-| `label` | string | Expanded function label. | Disambiguate overload-like patterns. |
-| `kind` | string | Node kind, usually `function`. | Future compatibility checks. |
-| `packagePath` | string | Go package path. | Package-level aggregation and ownership. |
-| `packageName` | string | Package short name. | UI grouping convenience. |
-| `module` | object | Module metadata for this node. | Internal versus external module decisions. |
-| `purl` | string | Package URL for dependency mapping. | Component evidence linking in SBOM. |
-| `standard` | boolean | Standard library classification. | Filter stdlib-heavy fan-outs. |
-| `local` | boolean | Local module classification. | Focus on first-party execution paths. |
-| `external` | boolean | External dependency classification. | Third-party reachability insights. |
-| `synthetic` | boolean | Synthetic SSA function indicator. | Exclude compiler-generated nodes in UX. |
-| `signature` | string | Function signature text. | Method shape and call-compatibility review. |
-| `receiver` | string | Receiver type for methods. | OO-like method dispatch analysis. |
-| `position.*` | object | Source location for function definition. | Jump-to-code from graph nodes. |
+| Field         | Type    | Purpose                                          | Typical use case                            |
+| ------------- | ------- | ------------------------------------------------ | ------------------------------------------- |
+| `id`          | string  | Stable node id, generally SSA function identity. | Join key for edge processing.               |
+| `name`        | string  | Function short name.                             | Human-readable graph labels.                |
+| `label`       | string  | Expanded function label.                         | Disambiguate overload-like patterns.        |
+| `kind`        | string  | Node kind, usually `function`.                   | Future compatibility checks.                |
+| `packagePath` | string  | Go package path.                                 | Package-level aggregation and ownership.    |
+| `packageName` | string  | Package short name.                              | UI grouping convenience.                    |
+| `module`      | object  | Module metadata for this node.                   | Internal versus external module decisions.  |
+| `purl`        | string  | Package URL for dependency mapping.              | Component evidence linking in SBOM.         |
+| `standard`    | boolean | Standard library classification.                 | Filter stdlib-heavy fan-outs.               |
+| `local`       | boolean | Local module classification.                     | Focus on first-party execution paths.       |
+| `external`    | boolean | External dependency classification.              | Third-party reachability insights.          |
+| `synthetic`   | boolean | Synthetic SSA function indicator.                | Exclude compiler-generated nodes in UX.     |
+| `signature`   | string  | Function signature text.                         | Method shape and call-compatibility review. |
+| `receiver`    | string  | Receiver type for methods.                       | OO-like method dispatch analysis.           |
+| `position.*`  | object  | Source location for function definition.         | Jump-to-code from graph nodes.              |
 
 ### `callGraph.edges[]` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `id` | string | Stable edge id. | De-duplication and graph diffs. |
-| `sourceId` | string | Caller node id. | Upstream traversal. |
-| `targetId` | string | Callee node id. | Downstream traversal. |
-| `sourceName` | string | Caller function text. | Fast context in logs/UI. |
-| `targetName` | string | Callee function text. | Fast context in logs/UI. |
-| `sourcePurl` | string | Caller package URL. | Component-level stack evidence. |
-| `sinkPurl` | string | Callee package URL. | Component-level stack evidence. |
-| `purls[]` | string array | Combined purls seen on edge. | Dependency evidence enrichment. |
-| `callType` | string | `static` or `dynamic`. | Confidence scoring and triage order. |
-| `static` | boolean | Static callsite marker. | Precision-oriented filtering. |
-| `position.*` | object | Source location of callsite. | File and line call stack rendering. |
-| `description` | string | Optional edge description. | Custom narratives in future exporters. |
-| `properties` | object | Optional edge metadata map. | Extended analytics without schema churn. |
+| Field         | Type         | Purpose                      | Typical use case                         |
+| ------------- | ------------ | ---------------------------- | ---------------------------------------- |
+| `id`          | string       | Stable edge id.              | De-duplication and graph diffs.          |
+| `sourceId`    | string       | Caller node id.              | Upstream traversal.                      |
+| `targetId`    | string       | Callee node id.              | Downstream traversal.                    |
+| `sourceName`  | string       | Caller function text.        | Fast context in logs/UI.                 |
+| `targetName`  | string       | Callee function text.        | Fast context in logs/UI.                 |
+| `sourcePurl`  | string       | Caller package URL.          | Component-level stack evidence.          |
+| `sinkPurl`    | string       | Callee package URL.          | Component-level stack evidence.          |
+| `purls[]`     | string array | Combined purls seen on edge. | Dependency evidence enrichment.          |
+| `callType`    | string       | `static` or `dynamic`.       | Confidence scoring and triage order.     |
+| `static`      | boolean      | Static callsite marker.      | Precision-oriented filtering.            |
+| `position.*`  | object       | Source location of callsite. | File and line call stack rendering.      |
+| `description` | string       | Optional edge description.   | Custom narratives in future exporters.   |
+| `properties`  | object       | Optional edge metadata map.  | Extended analytics without schema churn. |
 
 ## Data-flow JSON reference
 
@@ -114,140 +114,140 @@ The `dataFlow` section exists only when `--dataflow` is not `none`.
 
 ### `dataFlow` section
 
-| JSON path | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `dataFlow.mode` | string | Effective data-flow mode. | Confirm security versus all-mode operation. |
-| `dataFlow.nodes[]` | array of `DataFlowNode` | Taint graph nodes. | Interactive path inspection. |
-| `dataFlow.edges[]` | array of `DataFlowEdge` | Taint transitions between nodes. | Explain propagation hops. |
-| `dataFlow.slices[]` | array of `DataFlowSlice` | Source-to-sink traces selected for output. | Triage and evidence export. |
-| `dataFlow.patterns` | `DataFlowPatternSet` | Active source/sink/sanitizer patterns. | Explain why a flow was or was not matched. |
-| `dataFlow.summaries[]` | `DataFlowMethodSummary` | Interprocedural summary models. | Debug summary replay quality. |
-| `dataFlow.diagnostics[]` | array | Data-flow analysis diagnostics. | Understand truncation and skipped coverage. |
-| `dataFlow.stats.*` | object | Counts, performance, and quality metrics. | Capacity planning and confidence scoring. |
+| JSON path                | Type                     | Purpose                                    | Typical use case                            |
+| ------------------------ | ------------------------ | ------------------------------------------ | ------------------------------------------- |
+| `dataFlow.mode`          | string                   | Effective data-flow mode.                  | Confirm security versus all-mode operation. |
+| `dataFlow.nodes[]`       | array of `DataFlowNode`  | Taint graph nodes.                         | Interactive path inspection.                |
+| `dataFlow.edges[]`       | array of `DataFlowEdge`  | Taint transitions between nodes.           | Explain propagation hops.                   |
+| `dataFlow.slices[]`      | array of `DataFlowSlice` | Source-to-sink traces selected for output. | Triage and evidence export.                 |
+| `dataFlow.patterns`      | `DataFlowPatternSet`     | Active source/sink/sanitizer patterns.     | Explain why a flow was or was not matched.  |
+| `dataFlow.summaries[]`   | `DataFlowMethodSummary`  | Interprocedural summary models.            | Debug summary replay quality.               |
+| `dataFlow.diagnostics[]` | array                    | Data-flow analysis diagnostics.            | Understand truncation and skipped coverage. |
+| `dataFlow.stats.*`       | object                   | Counts, performance, and quality metrics.  | Capacity planning and confidence scoring.   |
 
 ### `dataFlow.patterns` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `sources[]` | array of `DataFlowPattern` | Source match rules. | Validate ingress coverage for APIs. |
-| `sinks[]` | array of `DataFlowPattern` | Sink match rules. | Validate dangerous boundary coverage. |
-| `passthroughs[]` | array of `DataFlowPattern` | Propagation helpers. | Reduce false negatives in wrappers. |
-| `sanitizers[]` | array of `DataFlowPattern` | Taint reduction or stop rules. | Suppress known-safe transformed flows. |
-| `packs[]` | string array | Enabled pattern packs. | Confirm profile-level policy selection. |
+| Field            | Type                       | Purpose                        | Typical use case                        |
+| ---------------- | -------------------------- | ------------------------------ | --------------------------------------- |
+| `sources[]`      | array of `DataFlowPattern` | Source match rules.            | Validate ingress coverage for APIs.     |
+| `sinks[]`        | array of `DataFlowPattern` | Sink match rules.              | Validate dangerous boundary coverage.   |
+| `passthroughs[]` | array of `DataFlowPattern` | Propagation helpers.           | Reduce false negatives in wrappers.     |
+| `sanitizers[]`   | array of `DataFlowPattern` | Taint reduction or stop rules. | Suppress known-safe transformed flows.  |
+| `packs[]`        | string array               | Enabled pattern packs.         | Confirm profile-level policy selection. |
 
 ### `DataFlowPattern` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `target` | string | Pattern target class: source, sink, passthrough, sanitizer. | Rule routing and UI labeling. |
-| `kind` | string | Match domain such as function, package, type, parameter. | Fine-grained matching behavior. |
-| `match` | string | Match operator: contains, exact, prefix, suffix, regex. | Rule precision tuning. |
-| `pattern` | string | Pattern value. | Library and symbol matching. |
-| `category` | string | Security/flow category. | Severity and policy mapping. |
-| `purl` | string | Optional purl override for rule. | Explicit dependency attribution. |
-| `description` | string | Human rule description. | Reviewer context and documentation. |
-| `taintKinds[]` | string array | Taint labels to propagate. | Data classification and policy filtering. |
-| `removesTaintKinds[]` | string array | Taint kinds removed by sanitizer. | Safe-transform modeling. |
-| `sanitizesCategories[]` | string array | Sink categories suppressed after sanitization. | Category-aware sink suppression. |
-| `relevantArguments[]` | integer array | Sink argument indexes to inspect. | Accurate sink targeting for APIs. |
-| `receiverRelevant` | boolean | Whether method receiver is sink-relevant. | Receiver-side taint checks. |
-| `ruleId`, `ruleName` | strings | Rule metadata attached to slices. | Findings normalization and suppression logic. |
-| `severity`, `riskScore` | string, integer | Priority metadata for matched sink rules. | Sort and threshold in triage queues. |
-| `confidence` | string | Confidence hint for pattern evidence. | Review prioritization. |
+| Field                   | Type            | Purpose                                                     | Typical use case                              |
+| ----------------------- | --------------- | ----------------------------------------------------------- | --------------------------------------------- |
+| `target`                | string          | Pattern target class: source, sink, passthrough, sanitizer. | Rule routing and UI labeling.                 |
+| `kind`                  | string          | Match domain such as function, package, type, parameter.    | Fine-grained matching behavior.               |
+| `match`                 | string          | Match operator: contains, exact, prefix, suffix, regex.     | Rule precision tuning.                        |
+| `pattern`               | string          | Pattern value.                                              | Library and symbol matching.                  |
+| `category`              | string          | Security/flow category.                                     | Severity and policy mapping.                  |
+| `purl`                  | string          | Optional purl override for rule.                            | Explicit dependency attribution.              |
+| `description`           | string          | Human rule description.                                     | Reviewer context and documentation.           |
+| `taintKinds[]`          | string array    | Taint labels to propagate.                                  | Data classification and policy filtering.     |
+| `removesTaintKinds[]`   | string array    | Taint kinds removed by sanitizer.                           | Safe-transform modeling.                      |
+| `sanitizesCategories[]` | string array    | Sink categories suppressed after sanitization.              | Category-aware sink suppression.              |
+| `relevantArguments[]`   | integer array   | Sink argument indexes to inspect.                           | Accurate sink targeting for APIs.             |
+| `receiverRelevant`      | boolean         | Whether method receiver is sink-relevant.                   | Receiver-side taint checks.                   |
+| `ruleId`, `ruleName`    | strings         | Rule metadata attached to slices.                           | Findings normalization and suppression logic. |
+| `severity`, `riskScore` | string, integer | Priority metadata for matched sink rules.                   | Sort and threshold in triage queues.          |
+| `confidence`            | string          | Confidence hint for pattern evidence.                       | Review prioritization.                        |
 
 ### `dataFlow.nodes[]` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `id` | string | Stable node id. | Joining nodes, edges, and slices. |
-| `kind` | string | Node role such as source, sink, call, store, sanitizer. | Visual graph styling and filtering. |
-| `name`, `symbol`, `type` | strings | Symbolic detail for node. | Analyst-readable path details. |
-| `packagePath` | string | Node package path. | Package ownership mapping. |
-| `module` | object | Module metadata at node level. | Internal versus external filtering. |
-| `purl` | string | Dependency mapping anchor. | SBOM evidence linking. |
-| `functionId`, `function` | strings | Function context. | Grouping and call-path explanation. |
-| `position.*` | object | Source location of node event. | Code navigation from findings. |
-| `source` | boolean | Marks source node. | Ingress counts and source filtering. |
-| `sink` | boolean | Marks sink node. | Egress counts and sink filtering. |
-| `category` | string | Node category, often sink/source type. | Policy and severity mapping. |
-| `taintKinds[]` | string array | Active taint labels at node. | Security and data-classification checks. |
-| `fieldPath` | string | Aggregate field/index context. | Struct and collection taint debugging. |
-| `confidence` | string | Node confidence hint. | Prioritization in review tooling. |
-| `properties` | object | Extra metadata map. | Rule and sanitizer metadata transport. |
+| Field                    | Type         | Purpose                                                 | Typical use case                         |
+| ------------------------ | ------------ | ------------------------------------------------------- | ---------------------------------------- |
+| `id`                     | string       | Stable node id.                                         | Joining nodes, edges, and slices.        |
+| `kind`                   | string       | Node role such as source, sink, call, store, sanitizer. | Visual graph styling and filtering.      |
+| `name`, `symbol`, `type` | strings      | Symbolic detail for node.                               | Analyst-readable path details.           |
+| `packagePath`            | string       | Node package path.                                      | Package ownership mapping.               |
+| `module`                 | object       | Module metadata at node level.                          | Internal versus external filtering.      |
+| `purl`                   | string       | Dependency mapping anchor.                              | SBOM evidence linking.                   |
+| `functionId`, `function` | strings      | Function context.                                       | Grouping and call-path explanation.      |
+| `position.*`             | object       | Source location of node event.                          | Code navigation from findings.           |
+| `source`                 | boolean      | Marks source node.                                      | Ingress counts and source filtering.     |
+| `sink`                   | boolean      | Marks sink node.                                        | Egress counts and sink filtering.        |
+| `category`               | string       | Node category, often sink/source type.                  | Policy and severity mapping.             |
+| `taintKinds[]`           | string array | Active taint labels at node.                            | Security and data-classification checks. |
+| `fieldPath`              | string       | Aggregate field/index context.                          | Struct and collection taint debugging.   |
+| `confidence`             | string       | Node confidence hint.                                   | Prioritization in review tooling.        |
+| `properties`             | object       | Extra metadata map.                                     | Rule and sanitizer metadata transport.   |
 
 ### `dataFlow.edges[]` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `id` | string | Stable edge id. | Graph diff and dedupe. |
-| `sourceId`, `targetId` | strings | Node ids connected by transition. | Path traversal. |
-| `kind` | string | Transition kind such as call-return, store, sink. | Explain propagation mechanism. |
-| `label` | string | Optional edge label. | Parameter or channel context display. |
-| `position.*` | object | Location associated with transition. | Trace review and auditing. |
-| `properties` | object | Optional extensible metadata. | Advanced telemetry without schema churn. |
+| Field                  | Type    | Purpose                                           | Typical use case                         |
+| ---------------------- | ------- | ------------------------------------------------- | ---------------------------------------- |
+| `id`                   | string  | Stable edge id.                                   | Graph diff and dedupe.                   |
+| `sourceId`, `targetId` | strings | Node ids connected by transition.                 | Path traversal.                          |
+| `kind`                 | string  | Transition kind such as call-return, store, sink. | Explain propagation mechanism.           |
+| `label`                | string  | Optional edge label.                              | Parameter or channel context display.    |
+| `position.*`           | object  | Location associated with transition.              | Trace review and auditing.               |
+| `properties`           | object  | Optional extensible metadata.                     | Advanced telemetry without schema churn. |
 
 ### `dataFlow.slices[]` fields
 
 A slice is the key triage record. It points to source and sink nodes and preserves ordered path identifiers.
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `id` | string | Stable slice id. | Deduplication and suppression keys. |
-| `sourceId`, `sinkId` | strings | Endpoint node ids for the trace. | Fast source-to-sink joins. |
-| `flowKey` | string | Stable grouping key for similar flows. | Duplicate group collapsing. |
-| `duplicateOf`, `duplicateIndex` | string, integer | Duplicate flow linkage. | UI compaction and de-noising. |
-| `nodeIds[]`, `edgeIds[]` | string arrays | Ordered path node and edge ids. | Multi-hop call stack rendering. |
-| `edgeKinds[]` | string array | Aggregated transition kinds in path. | Quick path-shape filtering. |
-| `sanitizerNodeIds[]` | string array | Sanitizer nodes on path. | Sanitized-flow review and policy logic. |
-| `pathLength` | integer | Number of edges in path. | Complexity and confidence heuristics. |
-| `sourceCategory`, `sinkCategory` | strings | Classified endpoints. | Rule routing and severity policy. |
-| `sourceName`, `sinkName` | strings | Symbol short names. | Human-readable triage context. |
-| `sourceSymbol`, `sinkSymbol` | strings | Symbol identities. | API-level sink/source mapping. |
-| `sourceFunction`, `sinkFunction` | strings | Function-level endpoint context. | Ownership and remediation routing. |
-| `sourcePackagePath`, `sinkPackagePath` | strings | Package-level endpoint context. | Team-level routing. |
-| `sourcePurl`, `sinkPurl`, `purls[]` | strings and string array | Dependency attribution for endpoints and path. | SBOM evidence and dependency policy. |
-| `sinkArgument`, `sinkArgumentIndex` | string, integer | Sink argument context. | Precision remediation at callsite. |
-| `taintKinds[]` | string array | Taint labels observed in path. | Data-class and policy checks. |
-| `fieldPaths[]` | string array | Aggregate field-level path context. | Object-graph taint debugging. |
-| `ruleId`, `ruleName` | strings | Rule metadata from sink classification. | Stable issue keys in ticketing systems. |
-| `severity`, `riskScore` | string, integer | Priority metadata. | Sorting and threshold gating. |
-| `sourceScope`, `sinkScope` | strings | Runtime/test/example scope context. | Ignore test-only findings in CI. |
-| `sourceCriticality`, `sinkCriticality` | strings | Criticality hints by category. | Prioritized review queues. |
-| `confidence` | string | Slice confidence. | Automated triage ranking. |
-| `description` | string | Human explanation of flow. | Analyst-friendly finding summary. |
-| `properties` | object | Extensible metadata map. | Pipeline-specific enrichment. |
+| Field                                  | Type                     | Purpose                                        | Typical use case                        |
+| -------------------------------------- | ------------------------ | ---------------------------------------------- | --------------------------------------- |
+| `id`                                   | string                   | Stable slice id.                               | Deduplication and suppression keys.     |
+| `sourceId`, `sinkId`                   | strings                  | Endpoint node ids for the trace.               | Fast source-to-sink joins.              |
+| `flowKey`                              | string                   | Stable grouping key for similar flows.         | Duplicate group collapsing.             |
+| `duplicateOf`, `duplicateIndex`        | string, integer          | Duplicate flow linkage.                        | UI compaction and de-noising.           |
+| `nodeIds[]`, `edgeIds[]`               | string arrays            | Ordered path node and edge ids.                | Multi-hop call stack rendering.         |
+| `edgeKinds[]`                          | string array             | Aggregated transition kinds in path.           | Quick path-shape filtering.             |
+| `sanitizerNodeIds[]`                   | string array             | Sanitizer nodes on path.                       | Sanitized-flow review and policy logic. |
+| `pathLength`                           | integer                  | Number of edges in path.                       | Complexity and confidence heuristics.   |
+| `sourceCategory`, `sinkCategory`       | strings                  | Classified endpoints.                          | Rule routing and severity policy.       |
+| `sourceName`, `sinkName`               | strings                  | Symbol short names.                            | Human-readable triage context.          |
+| `sourceSymbol`, `sinkSymbol`           | strings                  | Symbol identities.                             | API-level sink/source mapping.          |
+| `sourceFunction`, `sinkFunction`       | strings                  | Function-level endpoint context.               | Ownership and remediation routing.      |
+| `sourcePackagePath`, `sinkPackagePath` | strings                  | Package-level endpoint context.                | Team-level routing.                     |
+| `sourcePurl`, `sinkPurl`, `purls[]`    | strings and string array | Dependency attribution for endpoints and path. | SBOM evidence and dependency policy.    |
+| `sinkArgument`, `sinkArgumentIndex`    | string, integer          | Sink argument context.                         | Precision remediation at callsite.      |
+| `taintKinds[]`                         | string array             | Taint labels observed in path.                 | Data-class and policy checks.           |
+| `fieldPaths[]`                         | string array             | Aggregate field-level path context.            | Object-graph taint debugging.           |
+| `ruleId`, `ruleName`                   | strings                  | Rule metadata from sink classification.        | Stable issue keys in ticketing systems. |
+| `severity`, `riskScore`                | string, integer          | Priority metadata.                             | Sorting and threshold gating.           |
+| `sourceScope`, `sinkScope`             | strings                  | Runtime/test/example scope context.            | Ignore test-only findings in CI.        |
+| `sourceCriticality`, `sinkCriticality` | strings                  | Criticality hints by category.                 | Prioritized review queues.              |
+| `confidence`                           | string                   | Slice confidence.                              | Automated triage ranking.               |
+| `description`                          | string                   | Human explanation of flow.                     | Analyst-friendly finding summary.       |
+| `properties`                           | object                   | Extensible metadata map.                       | Pipeline-specific enrichment.           |
 
 ### `dataFlow.summaries[]` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
+| Field                    | Type    | Purpose                                  | Typical use case                           |
+| ------------------------ | ------- | ---------------------------------------- | ------------------------------------------ |
 | `functionId`, `function` | strings | Function identity and label for summary. | Traceability for interprocedural behavior. |
-| `packagePath` | string | Package context for summary. | Grouping by ownership. |
-| `paramToReturn[]` | array | Parameter-to-return taint propagation. | Wrapper and adapter behavior modeling. |
-| `paramToSink[]` | array | Parameter-to-sink category propagation. | Hidden sink exposure through wrappers. |
-| `receiverToReturn` | boolean | Receiver-to-return passthrough flag. | Fluent API taint modeling. |
-| `passthrough` | boolean | Generic passthrough marker. | Fast-path propagation logic. |
-| `confidence` | string | Summary confidence hint. | Summary quality tracking. |
-| `properties` | object | Extra summary metadata. | Debug and tuning metadata. |
+| `packagePath`            | string  | Package context for summary.             | Grouping by ownership.                     |
+| `paramToReturn[]`        | array   | Parameter-to-return taint propagation.   | Wrapper and adapter behavior modeling.     |
+| `paramToSink[]`          | array   | Parameter-to-sink category propagation.  | Hidden sink exposure through wrappers.     |
+| `receiverToReturn`       | boolean | Receiver-to-return passthrough flag.     | Fluent API taint modeling.                 |
+| `passthrough`            | boolean | Generic passthrough marker.              | Fast-path propagation logic.               |
+| `confidence`             | string  | Summary confidence hint.                 | Summary quality tracking.                  |
+| `properties`             | object  | Extra summary metadata.                  | Debug and tuning metadata.                 |
 
 ### `dataFlow.stats` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `sourceCount`, `sinkCount`, `sliceCount` | integers | Core flow counts. | Coverage and trend KPIs. |
-| `nodeCount`, `edgeCount` | integers | Graph size. | Capacity and complexity monitoring. |
-| `summaryCount` | integer | Number of inferred summaries. | Interprocedural model footprint. |
-| `candidateFunctionCount`, `functionCount` | integers | Candidate and analyzed function counts. | Understand analysis narrowing. |
-| `skippedFunctionCount` | integer | Functions skipped by safeguards. | Large-repo tradeoff visibility. |
-| `instructionCount` | integer | Approximate SSA instruction workload. | Capacity planning. |
-| `workerCount` | integer | Worker parallelism used. | Performance tuning. |
-| `elapsedMillis` | integer | End-to-end data-flow runtime. | SLA and runtime budgeting. |
-| `truncated` | boolean | Slice truncation flag. | Warn when output is incomplete. |
-| `truncationReasons[]` | string array | Human-readable truncation reasons. | Automatic retry with higher limits. |
-| `uniqueFlowCount` | integer | Unique flow groups by `flowKey`. | Noise ratio measurements. |
-| `duplicateSliceCount`, `duplicateGroupCount` | integers | Duplicate metrics. | UI collapse and dedupe tuning. |
-| `maxPathLength`, `averagePathLength` | integer, float | Path complexity metrics. | Risk heuristics and trend analysis. |
-| `sanitizedSliceCount` | integer | Number of slices with sanitizer involvement. | Sanitizer effectiveness reporting. |
+| Field                                        | Type           | Purpose                                      | Typical use case                    |
+| -------------------------------------------- | -------------- | -------------------------------------------- | ----------------------------------- |
+| `sourceCount`, `sinkCount`, `sliceCount`     | integers       | Core flow counts.                            | Coverage and trend KPIs.            |
+| `nodeCount`, `edgeCount`                     | integers       | Graph size.                                  | Capacity and complexity monitoring. |
+| `summaryCount`                               | integer        | Number of inferred summaries.                | Interprocedural model footprint.    |
+| `candidateFunctionCount`, `functionCount`    | integers       | Candidate and analyzed function counts.      | Understand analysis narrowing.      |
+| `skippedFunctionCount`                       | integer        | Functions skipped by safeguards.             | Large-repo tradeoff visibility.     |
+| `instructionCount`                           | integer        | Approximate SSA instruction workload.        | Capacity planning.                  |
+| `workerCount`                                | integer        | Worker parallelism used.                     | Performance tuning.                 |
+| `elapsedMillis`                              | integer        | End-to-end data-flow runtime.                | SLA and runtime budgeting.          |
+| `truncated`                                  | boolean        | Slice truncation flag.                       | Warn when output is incomplete.     |
+| `truncationReasons[]`                        | string array   | Human-readable truncation reasons.           | Automatic retry with higher limits. |
+| `uniqueFlowCount`                            | integer        | Unique flow groups by `flowKey`.             | Noise ratio measurements.           |
+| `duplicateSliceCount`, `duplicateGroupCount` | integers       | Duplicate metrics.                           | UI collapse and dedupe tuning.      |
+| `maxPathLength`, `averagePathLength`         | integer, float | Path complexity metrics.                     | Risk heuristics and trend analysis. |
+| `sanitizedSliceCount`                        | integer        | Number of slices with sanitizer involvement. | Sanitizer effectiveness reporting.  |
 
 ## Crypto JSON reference
 
@@ -255,92 +255,92 @@ The `crypto` section is populated from core analysis and does not require `--dat
 
 ### `crypto` section
 
-| JSON path | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `crypto.libraries[]` | array of `CryptoLibrary` | Crypto package/library imports and usage context. | Dependency-level crypto inventory. |
-| `crypto.assets[]` | array of `CryptoAsset` | Detected algorithms and certificates. | Crypto primitive and asset classification. |
-| `crypto.operations[]` | array of `CryptoOperation` | Concrete crypto operation usage records. | Encryption/signing/decryption pathway auditing. |
-| `crypto.materials[]` | array of `CryptoMaterial` | Key and secret material indicators. | Sensitive material handling governance. |
-| `crypto.protocols[]` | array of `CryptoProtocol` | Protocol usage like TLS. | Transport security posture analysis. |
-| `crypto.findings[]` | array of `CryptoFinding` | Rule-based crypto findings. | Policy violation reporting and gating. |
-| `crypto.properties` | object | Optional extensible metadata. | Custom pipeline enrichment. |
+| JSON path             | Type                       | Purpose                                           | Typical use case                                |
+| --------------------- | -------------------------- | ------------------------------------------------- | ----------------------------------------------- |
+| `crypto.libraries[]`  | array of `CryptoLibrary`   | Crypto package/library imports and usage context. | Dependency-level crypto inventory.              |
+| `crypto.assets[]`     | array of `CryptoAsset`     | Detected algorithms and certificates.             | Crypto primitive and asset classification.      |
+| `crypto.operations[]` | array of `CryptoOperation` | Concrete crypto operation usage records.          | Encryption/signing/decryption pathway auditing. |
+| `crypto.materials[]`  | array of `CryptoMaterial`  | Key and secret material indicators.               | Sensitive material handling governance.         |
+| `crypto.protocols[]`  | array of `CryptoProtocol`  | Protocol usage like TLS.                          | Transport security posture analysis.            |
+| `crypto.findings[]`   | array of `CryptoFinding`   | Rule-based crypto findings.                       | Policy violation reporting and gating.          |
+| `crypto.properties`   | object                     | Optional extensible metadata.                     | Custom pipeline enrichment.                     |
 
 ### `CryptoLibrary` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `id` | string | Stable record id. | Deduplication and cross-run comparison. |
-| `path` | string | Import path. | Library policy checks and allowlists. |
-| `family` | string | Crypto family classification. | Portfolio-level cryptography mapping. |
-| `standard` | boolean | Standard library indicator. | Third-party crypto dependency identification. |
-| `usageScope` | string | Runtime/test scope. | Runtime-only security review. |
-| `packagePath` | string | Package where usage appears. | Ownership mapping. |
-| `range.*` | object | Source range of evidence. | Jump-to-code review. |
-| `properties` | object | Optional metadata. | Extended analytics. |
+| Field         | Type    | Purpose                       | Typical use case                              |
+| ------------- | ------- | ----------------------------- | --------------------------------------------- |
+| `id`          | string  | Stable record id.             | Deduplication and cross-run comparison.       |
+| `path`        | string  | Import path.                  | Library policy checks and allowlists.         |
+| `family`      | string  | Crypto family classification. | Portfolio-level cryptography mapping.         |
+| `standard`    | boolean | Standard library indicator.   | Third-party crypto dependency identification. |
+| `usageScope`  | string  | Runtime/test scope.           | Runtime-only security review.                 |
+| `packagePath` | string  | Package where usage appears.  | Ownership mapping.                            |
+| `range.*`     | object  | Source range of evidence.     | Jump-to-code review.                          |
+| `properties`  | object  | Optional metadata.            | Extended analytics.                           |
 
 ### `CryptoAsset` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `id` | string | Stable asset id. | Joins with operations and findings. |
-| `name` | string | Asset name, often algorithm name. | Human-readable inventory. |
-| `assetType` | string | Asset class such as algorithm or certificate. | Category-based policy controls. |
-| `primitive` | string | Primitive family when known. | Primitive governance and migration planning. |
-| `strength` | string | Strength indicator when inferable. | Weak crypto tracking. |
-| `standard` | string | Referenced standard metadata. | Compliance reporting. |
-| `oid` | string | Algorithm or certificate OID when available. | Accurate cryptographic normalization. |
-| `packagePath`, `symbol`, `usageScope` | strings | Context metadata for source origin. | Ownership and triage routing. |
-| `range.*` | object | Source range. | Code navigation from findings. |
-| `properties` | object | Optional metadata map. | Context enrichment. |
+| Field                                 | Type    | Purpose                                       | Typical use case                             |
+| ------------------------------------- | ------- | --------------------------------------------- | -------------------------------------------- |
+| `id`                                  | string  | Stable asset id.                              | Joins with operations and findings.          |
+| `name`                                | string  | Asset name, often algorithm name.             | Human-readable inventory.                    |
+| `assetType`                           | string  | Asset class such as algorithm or certificate. | Category-based policy controls.              |
+| `primitive`                           | string  | Primitive family when known.                  | Primitive governance and migration planning. |
+| `strength`                            | string  | Strength indicator when inferable.            | Weak crypto tracking.                        |
+| `standard`                            | string  | Referenced standard metadata.                 | Compliance reporting.                        |
+| `oid`                                 | string  | Algorithm or certificate OID when available.  | Accurate cryptographic normalization.        |
+| `packagePath`, `symbol`, `usageScope` | strings | Context metadata for source origin.           | Ownership and triage routing.                |
+| `range.*`                             | object  | Source range.                                 | Code navigation from findings.               |
+| `properties`                          | object  | Optional metadata map.                        | Context enrichment.                          |
 
 ### `CryptoOperation` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `id` | string | Stable operation id. | Change detection and diffing. |
-| `operationType` | string | Operation class such as encrypt, decrypt, sign. | Operation-specific policy checks. |
-| `algorithm` | string | Algorithm name if inferred. | Algorithm usage metrics. |
-| `assetId` | string | Linked `CryptoAsset` id. | Graphing operation-to-asset relation. |
-| `packagePath`, `symbol`, `usageScope` | strings | Code context metadata. | Team-level remediation routing. |
-| `range.*` | object | Source range. | Source inspection from reports. |
-| `properties` | object | Optional metadata. | Pipeline-specific augmentation. |
+| Field                                 | Type    | Purpose                                         | Typical use case                      |
+| ------------------------------------- | ------- | ----------------------------------------------- | ------------------------------------- |
+| `id`                                  | string  | Stable operation id.                            | Change detection and diffing.         |
+| `operationType`                       | string  | Operation class such as encrypt, decrypt, sign. | Operation-specific policy checks.     |
+| `algorithm`                           | string  | Algorithm name if inferred.                     | Algorithm usage metrics.              |
+| `assetId`                             | string  | Linked `CryptoAsset` id.                        | Graphing operation-to-asset relation. |
+| `packagePath`, `symbol`, `usageScope` | strings | Code context metadata.                          | Team-level remediation routing.       |
+| `range.*`                             | object  | Source range.                                   | Source inspection from reports.       |
+| `properties`                          | object  | Optional metadata.                              | Pipeline-specific augmentation.       |
 
 ### `CryptoMaterial` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `id` | string | Stable material id. | Deduplication and trend analysis. |
-| `type` | string | Material type such as key, secret, nonce. | Sensitive data policy mapping. |
-| `name` | string | Material identifier when available. | Human triage context. |
-| `packagePath`, `symbol`, `usageScope` | strings | Source context. | Ownership and prioritization. |
-| `range.*` | object | Source range. | Review navigation. |
-| `properties` | object | Optional metadata. | Additional context transport. |
+| Field                                 | Type    | Purpose                                   | Typical use case                  |
+| ------------------------------------- | ------- | ----------------------------------------- | --------------------------------- |
+| `id`                                  | string  | Stable material id.                       | Deduplication and trend analysis. |
+| `type`                                | string  | Material type such as key, secret, nonce. | Sensitive data policy mapping.    |
+| `name`                                | string  | Material identifier when available.       | Human triage context.             |
+| `packagePath`, `symbol`, `usageScope` | strings | Source context.                           | Ownership and prioritization.     |
+| `range.*`                             | object  | Source range.                             | Review navigation.                |
+| `properties`                          | object  | Optional metadata.                        | Additional context transport.     |
 
 ### `CryptoProtocol` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `id` | string | Stable protocol id. | Diffs and historical tracking. |
-| `name` | string | Protocol name. | Inventory and policy checks. |
-| `type` | string | Protocol category. | Grouped compliance reporting. |
-| `version` | string | Protocol version when inferable. | Legacy protocol detection. |
-| `packagePath`, `symbol`, `usageScope` | strings | Source context. | Ownership-aware remediation. |
-| `range.*` | object | Source range. | Jump-to-source workflow. |
-| `properties` | object | Optional metadata. | Extended reporting. |
+| Field                                 | Type    | Purpose                          | Typical use case               |
+| ------------------------------------- | ------- | -------------------------------- | ------------------------------ |
+| `id`                                  | string  | Stable protocol id.              | Diffs and historical tracking. |
+| `name`                                | string  | Protocol name.                   | Inventory and policy checks.   |
+| `type`                                | string  | Protocol category.               | Grouped compliance reporting.  |
+| `version`                             | string  | Protocol version when inferable. | Legacy protocol detection.     |
+| `packagePath`, `symbol`, `usageScope` | strings | Source context.                  | Ownership-aware remediation.   |
+| `range.*`                             | object  | Source range.                    | Jump-to-source workflow.       |
+| `properties`                          | object  | Optional metadata.               | Extended reporting.            |
 
 ### `CryptoFinding` fields
 
-| Field | Type | Purpose | Typical use case |
-| --- | --- | --- | --- |
-| `id` | string | Stable finding id. | Deduplication and suppression control. |
-| `ruleId` | string | Rule identifier. | Policy rule mapping. |
-| `severity` | string | Finding severity. | Prioritized triage queues. |
-| `confidence` | string | Evidence confidence. | Auto-triage quality scoring. |
-| `summary`, `recommendation` | strings | Human explanation and action guidance. | Developer-facing remediation output. |
-| `packagePath`, `usageScope` | strings | Context metadata. | Runtime-only gating and ownership. |
-| `assetId`, `operationId`, `materialId` | strings | Links to crypto evidence records. | Graph-based triage workflows. |
-| `range.*` | object | Source range. | Editor jump links. |
-| `properties` | object | Optional metadata. | Extended pipeline integrations. |
+| Field                                  | Type    | Purpose                                | Typical use case                       |
+| -------------------------------------- | ------- | -------------------------------------- | -------------------------------------- |
+| `id`                                   | string  | Stable finding id.                     | Deduplication and suppression control. |
+| `ruleId`                               | string  | Rule identifier.                       | Policy rule mapping.                   |
+| `severity`                             | string  | Finding severity.                      | Prioritized triage queues.             |
+| `confidence`                           | string  | Evidence confidence.                   | Auto-triage quality scoring.           |
+| `summary`, `recommendation`            | strings | Human explanation and action guidance. | Developer-facing remediation output.   |
+| `packagePath`, `usageScope`            | strings | Context metadata.                      | Runtime-only gating and ownership.     |
+| `assetId`, `operationId`, `materialId` | strings | Links to crypto evidence records.      | Graph-based triage workflows.          |
+| `range.*`                              | object  | Source range.                          | Editor jump links.                     |
+| `properties`                           | object  | Optional metadata.                     | Extended pipeline integrations.        |
 
 ## Practical consumption patterns
 

--- a/thirdparty/golem/JSON_ATTRIBUTE_REFERENCE.md
+++ b/thirdparty/golem/JSON_ATTRIBUTE_REFERENCE.md
@@ -1,0 +1,365 @@
+# Golem JSON Attribute Reference
+
+This document explains the JSON report emitted by Golem with a focus on call graph, data-flow, and crypto evidence. It is designed for engineering teams that consume Golem output in automation, dashboards, and triage workflows.
+
+The canonical schema lives in `internal/model/model.go`.
+
+## Scope and option behavior
+
+Golem always emits a report envelope and core source evidence. Call graph and data-flow sections are optional. Crypto evidence is always collected from parsed source and type information.
+
+| Invocation option | Allowed values | JSON sections affected | What changes in output |
+| --- | --- | --- | --- |
+| `--callgraph` | `none`, `static`, `cha`, `rta`, `vta` | `callGraph`, `stats.callGraph*` | When not `none`, `callGraph` contains graph nodes, edges, diagnostics, and stats. |
+| `--dataflow` | `none`, `security`, `crypto`, `all` | `dataFlow`, `stats.dataFlow*` | When not `none`, `dataFlow` contains taint slices, nodes, edges, summaries, diagnostics, and stats. |
+| `--dataflow-callgraph` | `none`, `static`, `cha`, `rta`, `vta` | `dataFlow.diagnostics`, slice quality | Controls dynamic summary replay for data-flow interprocedural propagation. |
+| `--dataflow-pattern-packs` | `all`, `base`, `http`, `frameworks`, `data`, `filesystem`, `process`, `crypto`, `native`, `config`, `cloud` | `dataFlow.patterns` and downstream slices | Changes which sources, sinks, passthroughs, and sanitizers can match. |
+| `--include-stdlib` | boolean | `callGraph`, `dataFlow`, core usages | Includes standard library nodes/usages when enabled. |
+| `--include-local` | boolean | `callGraph`, `dataFlow`, core usages | Controls whether local module symbols are included. |
+| `--include-all-flows` | boolean | `callGraph`, `dataFlow` | When false, external-only module-cache flows are filtered out. |
+
+## Report envelope
+
+The top-level `Report` carries metadata plus optional analysis sections.
+
+| JSON path | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `schemaVersion` | string | Versioned schema URL for compatibility checks. | Contract gating in ingestion pipelines. |
+| `tool.name` | string | Producer tool name. | Multi-tool provenance in merged evidence. |
+| `tool.version` | string | Producer version string. | Drift analysis and reproducibility. |
+| `runtime.*` | object | Host/runtime context used during analysis. | Explain platform-specific evidence differences. |
+| `options.*` | object | Effective analysis options persisted in report. | Auditing and replay of analysis behavior. |
+| `packages`, `files`, `imports`, `declarations`, `usages` | arrays | Core source and symbol evidence. | Occurrence evidence and code ownership mapping. |
+| `securitySignals` | array | Security API pattern observations. | Lightweight risk surfacing before taint review. |
+| `crypto` | object, optional | Crypto-focused evidence extracted from source. | CBOM-like enrichment and crypto policy checks. |
+| `callGraph` | object, optional | Call graph section when enabled. | Reachability and blast radius analysis. |
+| `dataFlow` | object, optional | Data-flow section when enabled. | Source-to-sink triage and exploitability review. |
+| `diagnostics` | array | Global diagnostic messages. | Handling partial analysis gracefully. |
+| `stats` | object | Aggregate counters across evidence sections. | Dashboards, trend baselining, quality checks. |
+
+## `options` object details
+
+`options` is useful when reports are stored long-term and reviewed out of band.
+
+| JSON path | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `options.directory` | string | Absolute analysis root used by Golem. | Correlate evidence paths to source checkout. |
+| `options.patterns[]` | string | `go/packages` patterns analyzed. | Explain missing packages due to narrowed scope. |
+| `options.buildTags[]` | string | Build tags applied at load time. | Compare prod versus test build surfaces. |
+| `options.tests` | boolean | Test variants included or not. | Separate runtime evidence from test-only evidence. |
+| `options.noRecurse` | boolean | Recursive module discovery disabled flag. | Multi-module repository behavior auditing. |
+| `options.includeAllFlows` | boolean | External-only flow filtering control. | Keep or suppress third-party-only call/flow paths. |
+| `options.callGraphMode` | string | Effective call graph mode. | Precision versus performance tuning. |
+| `options.dataFlowMode` | string | Effective data-flow mode. | Security-only or broad taint modeling. |
+| `options.dataFlowCallGraphMode` | string | Dynamic summary replay mode for data-flow. | Improve interprocedural coverage in large codebases. |
+| `options.dataFlowPacks[]` | string | Active pattern packs. | Validate expected source and sink coverage. |
+
+## Call graph JSON reference
+
+The `callGraph` section exists only when `--callgraph` is not `none`.
+
+### `callGraph` section
+
+| JSON path | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `callGraph.mode` | string | Requested mode. | Verify requested algorithm path. |
+| `callGraph.algorithm` | string | Effective algorithm used internally. | Debug mode coercions or fallback behavior. |
+| `callGraph.nodes[]` | array of `CallGraphNode` | Function-level graph vertices. | API fan-in and fan-out exploration. |
+| `callGraph.edges[]` | array of `CallGraphEdge` | Caller to callee relations. | Reachability and impact tracing. |
+| `callGraph.diagnostics[]` | array | Call graph construction issues. | Explain graph sparsity or unsupported shapes. |
+| `callGraph.stats.nodeCount` | integer | Number of graph nodes emitted. | Sanity checks and trend monitoring. |
+| `callGraph.stats.edgeCount` | integer | Number of graph edges emitted. | Graph density checks over time. |
+
+### `callGraph.nodes[]` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `id` | string | Stable node id, generally SSA function identity. | Join key for edge processing. |
+| `name` | string | Function short name. | Human-readable graph labels. |
+| `label` | string | Expanded function label. | Disambiguate overload-like patterns. |
+| `kind` | string | Node kind, usually `function`. | Future compatibility checks. |
+| `packagePath` | string | Go package path. | Package-level aggregation and ownership. |
+| `packageName` | string | Package short name. | UI grouping convenience. |
+| `module` | object | Module metadata for this node. | Internal versus external module decisions. |
+| `purl` | string | Package URL for dependency mapping. | Component evidence linking in SBOM. |
+| `standard` | boolean | Standard library classification. | Filter stdlib-heavy fan-outs. |
+| `local` | boolean | Local module classification. | Focus on first-party execution paths. |
+| `external` | boolean | External dependency classification. | Third-party reachability insights. |
+| `synthetic` | boolean | Synthetic SSA function indicator. | Exclude compiler-generated nodes in UX. |
+| `signature` | string | Function signature text. | Method shape and call-compatibility review. |
+| `receiver` | string | Receiver type for methods. | OO-like method dispatch analysis. |
+| `position.*` | object | Source location for function definition. | Jump-to-code from graph nodes. |
+
+### `callGraph.edges[]` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `id` | string | Stable edge id. | De-duplication and graph diffs. |
+| `sourceId` | string | Caller node id. | Upstream traversal. |
+| `targetId` | string | Callee node id. | Downstream traversal. |
+| `sourceName` | string | Caller function text. | Fast context in logs/UI. |
+| `targetName` | string | Callee function text. | Fast context in logs/UI. |
+| `sourcePurl` | string | Caller package URL. | Component-level stack evidence. |
+| `sinkPurl` | string | Callee package URL. | Component-level stack evidence. |
+| `purls[]` | string array | Combined purls seen on edge. | Dependency evidence enrichment. |
+| `callType` | string | `static` or `dynamic`. | Confidence scoring and triage order. |
+| `static` | boolean | Static callsite marker. | Precision-oriented filtering. |
+| `position.*` | object | Source location of callsite. | File and line call stack rendering. |
+| `description` | string | Optional edge description. | Custom narratives in future exporters. |
+| `properties` | object | Optional edge metadata map. | Extended analytics without schema churn. |
+
+## Data-flow JSON reference
+
+The `dataFlow` section exists only when `--dataflow` is not `none`.
+
+### `dataFlow` section
+
+| JSON path | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `dataFlow.mode` | string | Effective data-flow mode. | Confirm security versus all-mode operation. |
+| `dataFlow.nodes[]` | array of `DataFlowNode` | Taint graph nodes. | Interactive path inspection. |
+| `dataFlow.edges[]` | array of `DataFlowEdge` | Taint transitions between nodes. | Explain propagation hops. |
+| `dataFlow.slices[]` | array of `DataFlowSlice` | Source-to-sink traces selected for output. | Triage and evidence export. |
+| `dataFlow.patterns` | `DataFlowPatternSet` | Active source/sink/sanitizer patterns. | Explain why a flow was or was not matched. |
+| `dataFlow.summaries[]` | `DataFlowMethodSummary` | Interprocedural summary models. | Debug summary replay quality. |
+| `dataFlow.diagnostics[]` | array | Data-flow analysis diagnostics. | Understand truncation and skipped coverage. |
+| `dataFlow.stats.*` | object | Counts, performance, and quality metrics. | Capacity planning and confidence scoring. |
+
+### `dataFlow.patterns` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `sources[]` | array of `DataFlowPattern` | Source match rules. | Validate ingress coverage for APIs. |
+| `sinks[]` | array of `DataFlowPattern` | Sink match rules. | Validate dangerous boundary coverage. |
+| `passthroughs[]` | array of `DataFlowPattern` | Propagation helpers. | Reduce false negatives in wrappers. |
+| `sanitizers[]` | array of `DataFlowPattern` | Taint reduction or stop rules. | Suppress known-safe transformed flows. |
+| `packs[]` | string array | Enabled pattern packs. | Confirm profile-level policy selection. |
+
+### `DataFlowPattern` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `target` | string | Pattern target class: source, sink, passthrough, sanitizer. | Rule routing and UI labeling. |
+| `kind` | string | Match domain such as function, package, type, parameter. | Fine-grained matching behavior. |
+| `match` | string | Match operator: contains, exact, prefix, suffix, regex. | Rule precision tuning. |
+| `pattern` | string | Pattern value. | Library and symbol matching. |
+| `category` | string | Security/flow category. | Severity and policy mapping. |
+| `purl` | string | Optional purl override for rule. | Explicit dependency attribution. |
+| `description` | string | Human rule description. | Reviewer context and documentation. |
+| `taintKinds[]` | string array | Taint labels to propagate. | Data classification and policy filtering. |
+| `removesTaintKinds[]` | string array | Taint kinds removed by sanitizer. | Safe-transform modeling. |
+| `sanitizesCategories[]` | string array | Sink categories suppressed after sanitization. | Category-aware sink suppression. |
+| `relevantArguments[]` | integer array | Sink argument indexes to inspect. | Accurate sink targeting for APIs. |
+| `receiverRelevant` | boolean | Whether method receiver is sink-relevant. | Receiver-side taint checks. |
+| `ruleId`, `ruleName` | strings | Rule metadata attached to slices. | Findings normalization and suppression logic. |
+| `severity`, `riskScore` | string, integer | Priority metadata for matched sink rules. | Sort and threshold in triage queues. |
+| `confidence` | string | Confidence hint for pattern evidence. | Review prioritization. |
+
+### `dataFlow.nodes[]` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `id` | string | Stable node id. | Joining nodes, edges, and slices. |
+| `kind` | string | Node role such as source, sink, call, store, sanitizer. | Visual graph styling and filtering. |
+| `name`, `symbol`, `type` | strings | Symbolic detail for node. | Analyst-readable path details. |
+| `packagePath` | string | Node package path. | Package ownership mapping. |
+| `module` | object | Module metadata at node level. | Internal versus external filtering. |
+| `purl` | string | Dependency mapping anchor. | SBOM evidence linking. |
+| `functionId`, `function` | strings | Function context. | Grouping and call-path explanation. |
+| `position.*` | object | Source location of node event. | Code navigation from findings. |
+| `source` | boolean | Marks source node. | Ingress counts and source filtering. |
+| `sink` | boolean | Marks sink node. | Egress counts and sink filtering. |
+| `category` | string | Node category, often sink/source type. | Policy and severity mapping. |
+| `taintKinds[]` | string array | Active taint labels at node. | Security and data-classification checks. |
+| `fieldPath` | string | Aggregate field/index context. | Struct and collection taint debugging. |
+| `confidence` | string | Node confidence hint. | Prioritization in review tooling. |
+| `properties` | object | Extra metadata map. | Rule and sanitizer metadata transport. |
+
+### `dataFlow.edges[]` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `id` | string | Stable edge id. | Graph diff and dedupe. |
+| `sourceId`, `targetId` | strings | Node ids connected by transition. | Path traversal. |
+| `kind` | string | Transition kind such as call-return, store, sink. | Explain propagation mechanism. |
+| `label` | string | Optional edge label. | Parameter or channel context display. |
+| `position.*` | object | Location associated with transition. | Trace review and auditing. |
+| `properties` | object | Optional extensible metadata. | Advanced telemetry without schema churn. |
+
+### `dataFlow.slices[]` fields
+
+A slice is the key triage record. It points to source and sink nodes and preserves ordered path identifiers.
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `id` | string | Stable slice id. | Deduplication and suppression keys. |
+| `sourceId`, `sinkId` | strings | Endpoint node ids for the trace. | Fast source-to-sink joins. |
+| `flowKey` | string | Stable grouping key for similar flows. | Duplicate group collapsing. |
+| `duplicateOf`, `duplicateIndex` | string, integer | Duplicate flow linkage. | UI compaction and de-noising. |
+| `nodeIds[]`, `edgeIds[]` | string arrays | Ordered path node and edge ids. | Multi-hop call stack rendering. |
+| `edgeKinds[]` | string array | Aggregated transition kinds in path. | Quick path-shape filtering. |
+| `sanitizerNodeIds[]` | string array | Sanitizer nodes on path. | Sanitized-flow review and policy logic. |
+| `pathLength` | integer | Number of edges in path. | Complexity and confidence heuristics. |
+| `sourceCategory`, `sinkCategory` | strings | Classified endpoints. | Rule routing and severity policy. |
+| `sourceName`, `sinkName` | strings | Symbol short names. | Human-readable triage context. |
+| `sourceSymbol`, `sinkSymbol` | strings | Symbol identities. | API-level sink/source mapping. |
+| `sourceFunction`, `sinkFunction` | strings | Function-level endpoint context. | Ownership and remediation routing. |
+| `sourcePackagePath`, `sinkPackagePath` | strings | Package-level endpoint context. | Team-level routing. |
+| `sourcePurl`, `sinkPurl`, `purls[]` | strings and string array | Dependency attribution for endpoints and path. | SBOM evidence and dependency policy. |
+| `sinkArgument`, `sinkArgumentIndex` | string, integer | Sink argument context. | Precision remediation at callsite. |
+| `taintKinds[]` | string array | Taint labels observed in path. | Data-class and policy checks. |
+| `fieldPaths[]` | string array | Aggregate field-level path context. | Object-graph taint debugging. |
+| `ruleId`, `ruleName` | strings | Rule metadata from sink classification. | Stable issue keys in ticketing systems. |
+| `severity`, `riskScore` | string, integer | Priority metadata. | Sorting and threshold gating. |
+| `sourceScope`, `sinkScope` | strings | Runtime/test/example scope context. | Ignore test-only findings in CI. |
+| `sourceCriticality`, `sinkCriticality` | strings | Criticality hints by category. | Prioritized review queues. |
+| `confidence` | string | Slice confidence. | Automated triage ranking. |
+| `description` | string | Human explanation of flow. | Analyst-friendly finding summary. |
+| `properties` | object | Extensible metadata map. | Pipeline-specific enrichment. |
+
+### `dataFlow.summaries[]` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `functionId`, `function` | strings | Function identity and label for summary. | Traceability for interprocedural behavior. |
+| `packagePath` | string | Package context for summary. | Grouping by ownership. |
+| `paramToReturn[]` | array | Parameter-to-return taint propagation. | Wrapper and adapter behavior modeling. |
+| `paramToSink[]` | array | Parameter-to-sink category propagation. | Hidden sink exposure through wrappers. |
+| `receiverToReturn` | boolean | Receiver-to-return passthrough flag. | Fluent API taint modeling. |
+| `passthrough` | boolean | Generic passthrough marker. | Fast-path propagation logic. |
+| `confidence` | string | Summary confidence hint. | Summary quality tracking. |
+| `properties` | object | Extra summary metadata. | Debug and tuning metadata. |
+
+### `dataFlow.stats` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `sourceCount`, `sinkCount`, `sliceCount` | integers | Core flow counts. | Coverage and trend KPIs. |
+| `nodeCount`, `edgeCount` | integers | Graph size. | Capacity and complexity monitoring. |
+| `summaryCount` | integer | Number of inferred summaries. | Interprocedural model footprint. |
+| `candidateFunctionCount`, `functionCount` | integers | Candidate and analyzed function counts. | Understand analysis narrowing. |
+| `skippedFunctionCount` | integer | Functions skipped by safeguards. | Large-repo tradeoff visibility. |
+| `instructionCount` | integer | Approximate SSA instruction workload. | Capacity planning. |
+| `workerCount` | integer | Worker parallelism used. | Performance tuning. |
+| `elapsedMillis` | integer | End-to-end data-flow runtime. | SLA and runtime budgeting. |
+| `truncated` | boolean | Slice truncation flag. | Warn when output is incomplete. |
+| `truncationReasons[]` | string array | Human-readable truncation reasons. | Automatic retry with higher limits. |
+| `uniqueFlowCount` | integer | Unique flow groups by `flowKey`. | Noise ratio measurements. |
+| `duplicateSliceCount`, `duplicateGroupCount` | integers | Duplicate metrics. | UI collapse and dedupe tuning. |
+| `maxPathLength`, `averagePathLength` | integer, float | Path complexity metrics. | Risk heuristics and trend analysis. |
+| `sanitizedSliceCount` | integer | Number of slices with sanitizer involvement. | Sanitizer effectiveness reporting. |
+
+## Crypto JSON reference
+
+The `crypto` section is populated from core analysis and does not require `--dataflow`. Data-flow can still add crypto-relevant slices and metadata in `dataFlow`.
+
+### `crypto` section
+
+| JSON path | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `crypto.libraries[]` | array of `CryptoLibrary` | Crypto package/library imports and usage context. | Dependency-level crypto inventory. |
+| `crypto.assets[]` | array of `CryptoAsset` | Detected algorithms and certificates. | Crypto primitive and asset classification. |
+| `crypto.operations[]` | array of `CryptoOperation` | Concrete crypto operation usage records. | Encryption/signing/decryption pathway auditing. |
+| `crypto.materials[]` | array of `CryptoMaterial` | Key and secret material indicators. | Sensitive material handling governance. |
+| `crypto.protocols[]` | array of `CryptoProtocol` | Protocol usage like TLS. | Transport security posture analysis. |
+| `crypto.findings[]` | array of `CryptoFinding` | Rule-based crypto findings. | Policy violation reporting and gating. |
+| `crypto.properties` | object | Optional extensible metadata. | Custom pipeline enrichment. |
+
+### `CryptoLibrary` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `id` | string | Stable record id. | Deduplication and cross-run comparison. |
+| `path` | string | Import path. | Library policy checks and allowlists. |
+| `family` | string | Crypto family classification. | Portfolio-level cryptography mapping. |
+| `standard` | boolean | Standard library indicator. | Third-party crypto dependency identification. |
+| `usageScope` | string | Runtime/test scope. | Runtime-only security review. |
+| `packagePath` | string | Package where usage appears. | Ownership mapping. |
+| `range.*` | object | Source range of evidence. | Jump-to-code review. |
+| `properties` | object | Optional metadata. | Extended analytics. |
+
+### `CryptoAsset` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `id` | string | Stable asset id. | Joins with operations and findings. |
+| `name` | string | Asset name, often algorithm name. | Human-readable inventory. |
+| `assetType` | string | Asset class such as algorithm or certificate. | Category-based policy controls. |
+| `primitive` | string | Primitive family when known. | Primitive governance and migration planning. |
+| `strength` | string | Strength indicator when inferable. | Weak crypto tracking. |
+| `standard` | string | Referenced standard metadata. | Compliance reporting. |
+| `oid` | string | Algorithm or certificate OID when available. | Accurate cryptographic normalization. |
+| `packagePath`, `symbol`, `usageScope` | strings | Context metadata for source origin. | Ownership and triage routing. |
+| `range.*` | object | Source range. | Code navigation from findings. |
+| `properties` | object | Optional metadata map. | Context enrichment. |
+
+### `CryptoOperation` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `id` | string | Stable operation id. | Change detection and diffing. |
+| `operationType` | string | Operation class such as encrypt, decrypt, sign. | Operation-specific policy checks. |
+| `algorithm` | string | Algorithm name if inferred. | Algorithm usage metrics. |
+| `assetId` | string | Linked `CryptoAsset` id. | Graphing operation-to-asset relation. |
+| `packagePath`, `symbol`, `usageScope` | strings | Code context metadata. | Team-level remediation routing. |
+| `range.*` | object | Source range. | Source inspection from reports. |
+| `properties` | object | Optional metadata. | Pipeline-specific augmentation. |
+
+### `CryptoMaterial` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `id` | string | Stable material id. | Deduplication and trend analysis. |
+| `type` | string | Material type such as key, secret, nonce. | Sensitive data policy mapping. |
+| `name` | string | Material identifier when available. | Human triage context. |
+| `packagePath`, `symbol`, `usageScope` | strings | Source context. | Ownership and prioritization. |
+| `range.*` | object | Source range. | Review navigation. |
+| `properties` | object | Optional metadata. | Additional context transport. |
+
+### `CryptoProtocol` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `id` | string | Stable protocol id. | Diffs and historical tracking. |
+| `name` | string | Protocol name. | Inventory and policy checks. |
+| `type` | string | Protocol category. | Grouped compliance reporting. |
+| `version` | string | Protocol version when inferable. | Legacy protocol detection. |
+| `packagePath`, `symbol`, `usageScope` | strings | Source context. | Ownership-aware remediation. |
+| `range.*` | object | Source range. | Jump-to-source workflow. |
+| `properties` | object | Optional metadata. | Extended reporting. |
+
+### `CryptoFinding` fields
+
+| Field | Type | Purpose | Typical use case |
+| --- | --- | --- | --- |
+| `id` | string | Stable finding id. | Deduplication and suppression control. |
+| `ruleId` | string | Rule identifier. | Policy rule mapping. |
+| `severity` | string | Finding severity. | Prioritized triage queues. |
+| `confidence` | string | Evidence confidence. | Auto-triage quality scoring. |
+| `summary`, `recommendation` | strings | Human explanation and action guidance. | Developer-facing remediation output. |
+| `packagePath`, `usageScope` | strings | Context metadata. | Runtime-only gating and ownership. |
+| `assetId`, `operationId`, `materialId` | strings | Links to crypto evidence records. | Graph-based triage workflows. |
+| `range.*` | object | Source range. | Editor jump links. |
+| `properties` | object | Optional metadata. | Extended pipeline integrations. |
+
+## Practical consumption patterns
+
+### 1. Build a component call stack table
+
+Use `dataFlow.slices[*].nodeIds` and `callGraph.edges[*].position` to collect ordered file and line entries by resolved purl. Favor slices first, then enrich with call graph edges for broader coverage.
+
+### 2. Separate runtime and test evidence
+
+Use `sourceScope`, `sinkScope`, and `usageScope` fields. For CI gate decisions, drop findings where both source and sink are test-like scopes.
+
+### 3. Prioritize by confidence and impact
+
+Sort slices by `severity`, `riskScore`, `confidence`, then `pathLength`. For crypto, combine `crypto.findings[*].severity` with linked `assetId` and operation context.
+
+### 4. Detect incomplete runs
+
+Check `dataFlow.stats.truncated`, `dataFlow.stats.truncationReasons`, and section diagnostics. If truncated, rerun with larger slice budget or narrower patterns.
+
+## Notes on compatibility
+
+Field names in JSON use lower camel case as defined in model tags. Any unknown fields should be ignored by consumers for forward compatibility.

--- a/thirdparty/golem/JSON_ATTRIBUTE_REFERENCE.md
+++ b/thirdparty/golem/JSON_ATTRIBUTE_REFERENCE.md
@@ -49,6 +49,8 @@ The top-level `Report` carries metadata plus optional analysis sections.
 | `options.tests`                 | boolean | Test variants included or not.             | Separate runtime evidence from test-only evidence.   |
 | `options.noRecurse`             | boolean | Recursive module discovery disabled flag.  | Multi-module repository behavior auditing.           |
 | `options.includeAllFlows`       | boolean | External-only flow filtering control.      | Keep or suppress third-party-only call/flow paths.   |
+
+`options.noRecurse` and `options.includeAllFlows` are always emitted, including `false`, so downstream tooling can reliably audit effective defaults.
 | `options.callGraphMode`         | string  | Effective call graph mode.                 | Precision versus performance tuning.                 |
 | `options.dataFlowMode`          | string  | Effective data-flow mode.                  | Security-only or broad taint modeling.               |
 | `options.dataFlowCallGraphMode` | string  | Dynamic summary replay mode for data-flow. | Improve interprocedural coverage in large codebases. |

--- a/thirdparty/golem/Makefile
+++ b/thirdparty/golem/Makefile
@@ -1,6 +1,6 @@
 PATH := $(PATH):/usr/local/go/bin:$(HOME)/go/bin
 appname := golem
-version ?= 2.2.1
+version ?= 2.2.2
 sources := $(shell find cmd internal -type f -name '*.go')
 ldflags := -s -w -X main.version=$(version)
 

--- a/thirdparty/golem/README.md
+++ b/thirdparty/golem/README.md
@@ -23,6 +23,8 @@ go run ./cmd/golem analyze --dir . --tags prod,linux --tests --out golem-tests.j
 
 The default package pattern is `./...`. Use `--patterns` to narrow the load set and `--tags` or `--tests` to match the build shape you want to inspect.
 
+If `--dir` does not contain `go.mod` or `go.work`, Golem automatically discovers child directories containing `go.mod` and merges results across them. Use `--no-recurse` to disable this behavior.
+
 ## What Golem reads
 
 Golem uses `golang.org/x/tools/go/packages` with syntax, imports, dependencies, types, type information, file lists, module metadata, and type sizes enabled. Package loading is therefore close to what `go list` and the compiler see for the requested patterns, build tags, and test setting.
@@ -30,6 +32,8 @@ Golem uses `golang.org/x/tools/go/packages` with syntax, imports, dependencies, 
 The first analysis pass walks package ASTs and type information. It records imports, declarations, type-resolved library usages, build directives, native sidecar files, service and endpoint clues, security-sensitive API signals, and cryptographic evidence. SSA is built only when a call graph or data-flow mode is requested.
 
 The JSON model is defined in `internal/model/model.go`. The main report contains package-level and file-level evidence, global rollups, diagnostics, optional call graph data, and optional data-flow data.
+
+For a field-by-field JSON reference, see `JSON_ATTRIBUTE_REFERENCE.md`.
 
 ## Output formats
 
@@ -81,6 +85,8 @@ Within a function, taint is tracked through SSA values, stores, loads, map updat
 Sanitizers can either stop a trace completely or remove selected taint kinds. They can also mark categories as sanitized, which suppresses later sinks in those categories while allowing unrelated taint to continue. This lets a path sanitizer reduce filesystem findings without hiding a secret flowing to a log sink.
 
 A slice contains source and sink IDs, node and edge IDs, categories, taint kinds, package paths, package URLs, sink argument information, rule metadata, severity, risk score, confidence, path length, sanitizer nodes, duplicate grouping, and a stable `flowKey`. Data-flow graph sidecars include the nodes and edges used by the slices.
+
+By default, Golem drops call graph edges and data-flow slices that are entirely rooted in external Go module cache paths (for example `/go/pkg/mod/...`) to reduce third-party-only noise in downstream evidence. Use `--include-all-flows` to keep those flows.
 
 Large repositories can be controlled with these limits:
 

--- a/thirdparty/golem/README.md
+++ b/thirdparty/golem/README.md
@@ -43,13 +43,13 @@ For a field-by-field JSON reference, see `JSON_ATTRIBUTE_REFERENCE.md`.
 
 Call graphs are built from Go SSA using the implementations in `golang.org/x/tools/go/callgraph`:
 
-| Mode | Implementation | Practical behavior |
-| --- | --- | --- |
-| `none` | No graph | Fastest mode. Reports source evidence only. |
-| `static` | `static.CallGraph` | Fast and deterministic. Direct calls are reliable, dynamic dispatch is limited. |
-| `cha` | `cha.CallGraph` | More conservative for interface dispatch. Usually more edges. |
-| `rta` | `rta.Analyze` | Starts from discovered `init` and `main` roots. Useful for executable reachability. |
-| `vta` | `vta.CallGraph` | Uses variable type analysis over functions reachable in the static graph. Often more precise, but depends on the shapes supported by `x/tools`. |
+| Mode     | Implementation     | Practical behavior                                                                                                                              |
+| -------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `none`   | No graph           | Fastest mode. Reports source evidence only.                                                                                                     |
+| `static` | `static.CallGraph` | Fast and deterministic. Direct calls are reliable, dynamic dispatch is limited.                                                                 |
+| `cha`    | `cha.CallGraph`    | More conservative for interface dispatch. Usually more edges.                                                                                   |
+| `rta`    | `rta.Analyze`      | Starts from discovered `init` and `main` roots. Useful for executable reachability.                                                             |
+| `vta`    | `vta.CallGraph`    | Uses variable type analysis over functions reachable in the static graph. Often more precise, but depends on the shapes supported by `x/tools`. |
 
 Golem converts the raw graph into stable node and edge records. A node represents an SSA function with package path, package name, module, package URL when available, receiver, signature, local or external classification, standard library classification, synthetic flag, and source position. An edge records caller, callee, call site location, package URLs for both ends, and whether the call site has a static callee.
 
@@ -90,16 +90,16 @@ By default, Golem drops call graph edges and data-flow slices that are entirely 
 
 Large repositories can be controlled with these limits:
 
-| Option | Default | Purpose |
-| --- | ---: | --- |
-| `--dataflow-max-slices` | `1000` | Stop materializing slices after this count and emit truncation diagnostics. |
-| `--dataflow-workers` | `0` | Number of per-function workers. `0` uses available scheduler parallelism. |
-| `--dataflow-large-repo-functions` | `1000` | Function count where large-repo materialization safeguards start. |
-| `--dataflow-max-function-instructions` | `200` | Skip slice materialization for very large functions in large repositories. Summaries are still inferred. |
-| `--dataflow-max-trace-nodes` | `64` | Maximum node IDs retained in an in-memory trace. |
-| `--dataflow-max-trace-edges` | `128` | Maximum edge IDs retained in an in-memory trace. |
-| `--dataflow-skip-generated` | `false` | Skip generated files during slice materialization. |
-| `--dataflow-skip-tests` | `false` | Skip tests, examples, and benchmarks during slice materialization. |
+| Option                                 | Default | Purpose                                                                                                  |
+| -------------------------------------- | ------: | -------------------------------------------------------------------------------------------------------- |
+| `--dataflow-max-slices`                |  `1000` | Stop materializing slices after this count and emit truncation diagnostics.                              |
+| `--dataflow-workers`                   |     `0` | Number of per-function workers. `0` uses available scheduler parallelism.                                |
+| `--dataflow-large-repo-functions`      |  `1000` | Function count where large-repo materialization safeguards start.                                        |
+| `--dataflow-max-function-instructions` |   `200` | Skip slice materialization for very large functions in large repositories. Summaries are still inferred. |
+| `--dataflow-max-trace-nodes`           |    `64` | Maximum node IDs retained in an in-memory trace.                                                         |
+| `--dataflow-max-trace-edges`           |   `128` | Maximum edge IDs retained in an in-memory trace.                                                         |
+| `--dataflow-skip-generated`            | `false` | Skip generated files during slice materialization.                                                       |
+| `--dataflow-skip-tests`                | `false` | Skip tests, examples, and benchmarks during slice materialization.                                       |
 
 Use `--max-procs` to cap Go scheduler parallelism, `--memory-limit` to set Go's soft memory limit, and `--progress` to print coarse package loading, SSA, call graph, and data-flow progress logs.
 

--- a/thirdparty/golem/cmd/golem/main.go
+++ b/thirdparty/golem/cmd/golem/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cdxgen/cdxgen-plugins-bin/thirdparty/golem/internal/exporter"
 )
 
-var version = "2.2.0"
+var version = "2.2.2"
 
 func main() {
 	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
@@ -38,11 +38,13 @@ func run(args []string, stdout io.Writer, stderr io.Writer) error {
 	flags := flag.NewFlagSet("golem analyze", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	dir := flags.String("dir", ".", "Go module/workspace directory to analyze")
+	noRecurse := flags.Bool("no-recurse", false, "disable recursive child go.mod discovery when --dir has no go.mod/go.work")
 	patterns := flags.String("patterns", "./...", "comma-separated go/packages patterns")
 	formatValue := flags.String("format", "json", "output format: json, graphml, or gexf")
 	outFile := flags.String("out", "", "output file path; defaults to stdout")
 	callgraph := flags.String("callgraph", "none", "call graph mode: none, static, cha, rta, or vta")
 	dataflow := flags.String("dataflow", "none", "data-flow mode: none, security, crypto, or all")
+	includeAllFlows := flags.Bool("include-all-flows", false, "retain external-only flows/call stacks fully rooted in Go module cache paths")
 	dataflowPatterns := flags.String("dataflow-patterns", "", "optional JSON file with data-flow sources, sinks, passthroughs, and sanitizers")
 	dataflowPacks := flags.String("dataflow-pattern-packs", "all", "comma-separated data-flow pattern packs: all, base, http, frameworks, data, filesystem, process, crypto, native, config, cloud")
 	dataflowCallgraph := flags.String("dataflow-callgraph", "static", "call graph mode for data-flow dynamic summary replay: none, static, cha, rta, or vta")
@@ -99,7 +101,7 @@ func run(args []string, stdout io.Writer, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	report, err := analyzer.Analyze(analyzer.Options{Dir: *dir, Patterns: splitCSV(*patterns), BuildTags: splitCSV(*tags), Tests: *tests, IncludeStdlib: *includeStdlib, IncludeLocal: *includeLocal, CallGraphMode: mode, DataFlowMode: dfMode, DataFlowPacks: splitCSV(*dataflowPacks), DataFlowConfig: *dataflowPatterns, DataFlowMax: *dataflowMax, DataFlowCallGraphMode: dfCallgraphMode, DataFlowWorkers: *dataflowWorkers, DataFlowLargeRepoFunctions: *dataflowLargeRepoFunctions, DataFlowMaxFunctionInstructions: *dataflowMaxFunctionInstructions, DataFlowMaxTraceNodes: *dataflowMaxTraceNodes, DataFlowMaxTraceEdges: *dataflowMaxTraceEdges, DataFlowSkipGenerated: *dataflowSkipGenerated, DataFlowSkipTests: *dataflowSkipTests, MaxProcs: *maxProcs, MemoryLimit: memoryLimitBytes, Progress: *progress, ProgressInterval: *progressInterval, ProgressWriter: stderr, ToolVersion: version})
+	report, err := analyzer.Analyze(analyzer.Options{Dir: *dir, NoRecurse: *noRecurse, IncludeAllFlows: *includeAllFlows, Patterns: splitCSV(*patterns), BuildTags: splitCSV(*tags), Tests: *tests, IncludeStdlib: *includeStdlib, IncludeLocal: *includeLocal, CallGraphMode: mode, DataFlowMode: dfMode, DataFlowPacks: splitCSV(*dataflowPacks), DataFlowConfig: *dataflowPatterns, DataFlowMax: *dataflowMax, DataFlowCallGraphMode: dfCallgraphMode, DataFlowWorkers: *dataflowWorkers, DataFlowLargeRepoFunctions: *dataflowLargeRepoFunctions, DataFlowMaxFunctionInstructions: *dataflowMaxFunctionInstructions, DataFlowMaxTraceNodes: *dataflowMaxTraceNodes, DataFlowMaxTraceEdges: *dataflowMaxTraceEdges, DataFlowSkipGenerated: *dataflowSkipGenerated, DataFlowSkipTests: *dataflowSkipTests, MaxProcs: *maxProcs, MemoryLimit: memoryLimitBytes, Progress: *progress, ProgressInterval: *progressInterval, ProgressWriter: stderr, ToolVersion: version})
 	if err != nil {
 		return err
 	}
@@ -146,11 +148,13 @@ func printUsage(w io.Writer) {
 
 Options:
   --dir <path>             Go module/workspace directory to analyze (default: .)
+  --no-recurse             Disable recursive child go.mod discovery when root has no go.mod/go.work
   --patterns <patterns>    Comma-separated go/packages patterns (default: ./...)
   --format <format>        json, graphml, or gexf (default: json)
   --out <file>             Output file path (default: stdout)
   --callgraph <mode>       none, static, cha, rta, or vta (default: none)
   --dataflow <mode>        none, security, crypto, or all (default: none)
+  --include-all-flows      Keep external-only flows/call stacks rooted in module cache paths
   --dataflow-patterns <f>  Custom data-flow pattern JSON
   --dataflow-pattern-packs Comma-separated packs: all, base, http, frameworks, data, filesystem, process, crypto, native, config, cloud
   --dataflow-callgraph     none, static, cha, rta, or vta for data-flow dynamic summary replay

--- a/thirdparty/golem/internal/analyzer/analyzer_test.go
+++ b/thirdparty/golem/internal/analyzer/analyzer_test.go
@@ -541,6 +541,55 @@ func TestFilterExternalOnlyModuleCacheFlows(t *testing.T) {
 	}
 }
 
+func TestAnalyzeRecursiveNormalizesModesInMergedOptions(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "svc")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(child, "go.mod"), []byte("module example.com/rec\n\ngo 1.22\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(child, "main.go"), []byte("package main\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	report, err := Analyze(Options{Dir: root, ToolVersion: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Options.CallGraphMode != "none" || report.Options.DataFlowMode != "none" || report.Options.DataFlowCallGraphMode != "static" {
+		t.Fatalf("expected normalized modes in merged options, got %#v", report.Options)
+	}
+}
+
+func TestMergeReportsMergesSupplyChainAcrossChildren(t *testing.T) {
+	dst := &model.Report{SupplyChain: &model.SupplyChainEvidence{Replaces: []model.GoModDirective{{Kind: "replace", ModulePath: "example.com/a"}}, Excludes: []model.GoModDirective{{Kind: "exclude", ModulePath: "example.com/x"}}, Modules: []model.ModuleCompliance{{Path: "example.com/local", Main: true}}}}
+	src := &model.Report{SupplyChain: &model.SupplyChainEvidence{Replaces: []model.GoModDirective{{Kind: "replace", ModulePath: "example.com/b"}}, Excludes: []model.GoModDirective{{Kind: "exclude", ModulePath: "example.com/y"}}, Modules: []model.ModuleCompliance{{Path: "example.com/vendor", Vendored: true}}}}
+	mergeReports(dst, src)
+	if dst.SupplyChain == nil || len(dst.SupplyChain.Replaces) != 2 || len(dst.SupplyChain.Excludes) != 2 || len(dst.SupplyChain.Modules) != 2 {
+		t.Fatalf("expected merged supply-chain evidence, got %#v", dst.SupplyChain)
+	}
+	if dst.SupplyChain.WorkspaceModuleCount != 1 || dst.SupplyChain.VendorModuleCount != 1 {
+		t.Fatalf("expected recomputed workspace/vendor counts, got %#v", dst.SupplyChain)
+	}
+}
+
+func TestMergeReportsRecomputesMergedDataFlowStats(t *testing.T) {
+	dst := &model.Report{DataFlow: &model.DataFlowEvidence{Nodes: []model.DataFlowNode{{ID: "n1", Source: true}, {ID: "n2", Sink: true}}, Edges: []model.DataFlowEdge{{ID: "e1"}}, Slices: []model.DataFlowSlice{{ID: "s1", SourceID: "n1", SinkID: "n2", NodeIDs: []string{"n1", "n2"}, EdgeIDs: []string{"e1"}, FlowKey: "f1", PathLength: 1}}, Summaries: []model.DataFlowMethodSummary{{FunctionID: "fA"}}, Diagnostics: []model.Diagnostic{{Kind: "dataflow-budget", Message: "limit A"}}, Stats: model.DataFlowStats{CandidateFunctionCount: 3, FunctionCount: 2, InstructionCount: 9, WorkerCount: 2}}}
+	src := &model.Report{DataFlow: &model.DataFlowEvidence{Nodes: []model.DataFlowNode{{ID: "n3", Source: true}, {ID: "n4", Sink: true}}, Edges: []model.DataFlowEdge{{ID: "e2"}}, Slices: []model.DataFlowSlice{{ID: "s2", SourceID: "n3", SinkID: "n4", NodeIDs: []string{"n3", "n4"}, EdgeIDs: []string{"e2"}, FlowKey: "f2", PathLength: 2}}, Summaries: []model.DataFlowMethodSummary{{FunctionID: "fB"}}, Diagnostics: []model.Diagnostic{{Kind: "dataflow-budget", Message: "limit B"}}, Stats: model.DataFlowStats{CandidateFunctionCount: 4, FunctionCount: 3, InstructionCount: 11, WorkerCount: 3}}}
+	mergeReports(dst, src)
+	stats := dst.DataFlow.Stats
+	if stats.NodeCount != 4 || stats.EdgeCount != 2 || stats.SliceCount != 2 || stats.SourceCount != 2 || stats.SinkCount != 2 {
+		t.Fatalf("expected merged core data-flow stats, got %#v", stats)
+	}
+	if stats.SummaryCount != 2 || stats.CandidateFunctionCount != 7 || stats.FunctionCount != 5 || stats.InstructionCount != 20 || stats.WorkerCount != 3 {
+		t.Fatalf("expected merged aggregate/summaries stats, got %#v", stats)
+	}
+	if !stats.Truncated || len(stats.TruncationReasons) != 2 {
+		t.Fatalf("expected merged truncation metadata from diagnostics, got %#v", stats)
+	}
+}
+
 func TestDataFlowTestLikeFunctionPredicate(t *testing.T) {
 	if !dataFlowTestLikeFunction(filepath.Join("pkg", "handler_test.go"), nil) {
 		t.Fatal("expected _test.go file to be treated as test-like")

--- a/thirdparty/golem/internal/analyzer/analyzer_test.go
+++ b/thirdparty/golem/internal/analyzer/analyzer_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/cdxgen/cdxgen-plugins-bin/thirdparty/golem/internal/model"
 )
 
 func TestAnalyzeSimpleProject(t *testing.T) {
@@ -420,7 +422,7 @@ func TestDataFlowConfigurableBudgetsAndPatternMetadata(t *testing.T) {
 		t.Fatalf("expected configured data-flow options in report, got %#v", report.Options)
 	}
 	set := builtinDataFlowPatterns([]string{"all"})
-	var redirectArgs, httpErrorArgs, viperSource, cloudSink bool
+	var redirectArgs, httpErrorArgs, viperSource, cloudSink, zapSink, grpcClientSink bool
 	for _, sink := range set.Sinks {
 		if sink.Pattern == "http.Redirect" && len(sink.RelevantArguments) == 1 && sink.RelevantArguments[0] == 2 && sink.RuleID == "GOLEM-DATAFLOW-OPEN-REDIRECT" {
 			redirectArgs = true
@@ -431,14 +433,24 @@ func TestDataFlowConfigurableBudgetsAndPatternMetadata(t *testing.T) {
 		if sink.Category == "external-service" && strings.Contains(sink.Pattern, "aws-sdk-go") {
 			cloudSink = true
 		}
+		if sink.Category == "logging" && strings.Contains(sink.Pattern, "go.uber.org/zap") {
+			zapSink = true
+		}
+		if sink.Category == "external-service" && strings.Contains(sink.Pattern, "grpc.(*ClientConn).Invoke") {
+			grpcClientSink = true
+		}
 	}
+	var grpcSource bool
 	for _, source := range set.Sources {
 		if strings.Contains(source.Pattern, "viper.GetString") && source.Category == "configuration" {
 			viperSource = true
 		}
+		if strings.Contains(source.Pattern, "grpc/metadata.FromIncomingContext") && source.Category == "http-input" {
+			grpcSource = true
+		}
 	}
-	if !redirectArgs || !httpErrorArgs || !viperSource || !cloudSink {
-		t.Fatalf("expected enriched pattern metadata/packs redirect=%v httpError=%v viper=%v cloud=%v", redirectArgs, httpErrorArgs, viperSource, cloudSink)
+	if !redirectArgs || !httpErrorArgs || !viperSource || !cloudSink || !zapSink || !grpcClientSink || !grpcSource {
+		t.Fatalf("expected enriched pattern metadata redirect=%v httpError=%v viper=%v cloud=%v zap=%v grpcClient=%v grpcSource=%v", redirectArgs, httpErrorArgs, viperSource, cloudSink, zapSink, grpcClientSink, grpcSource)
 	}
 	narrow := builtinDataFlowPatterns([]string{"process"})
 	for _, source := range narrow.Sources {
@@ -450,6 +462,82 @@ func TestDataFlowConfigurableBudgetsAndPatternMetadata(t *testing.T) {
 		if sink.Category != "command-execution" && sink.Category != "dynamic-loading" {
 			t.Fatalf("explicit process pack should only include process sinks, got %#v", narrow.Sinks)
 		}
+	}
+}
+
+func TestDiscoverChildGoModuleDirs(t *testing.T) {
+	root := t.TempDir()
+	for _, path := range []string{
+		filepath.Join(root, "svc-a"),
+		filepath.Join(root, "svc-b", "nested"),
+		filepath.Join(root, ".git", "hooks"),
+	} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, mod := range []string{
+		filepath.Join(root, "svc-a", "go.mod"),
+		filepath.Join(root, "svc-b", "nested", "go.mod"),
+	} {
+		if err := os.WriteFile(mod, []byte("module example.com/test\n\ngo 1.22\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, ".git", "hooks", "go.mod"), []byte("module should/not/be/seen\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dirs, err := discoverChildGoModuleDirs(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirs) != 2 {
+		t.Fatalf("expected 2 discovered module dirs, got %#v", dirs)
+	}
+	if dirs[0] != filepath.Join(root, "svc-a") || dirs[1] != filepath.Join(root, "svc-b", "nested") {
+		t.Fatalf("unexpected module dirs %#v", dirs)
+	}
+}
+
+func TestFilterExternalOnlyModuleCacheFlows(t *testing.T) {
+	report := &model.Report{
+		CallGraph: &model.CallGraph{
+			Nodes: []model.CallGraphNode{
+				{ID: "local", Position: model.Position{Filename: "/workspace/service/main.go"}},
+				{ID: "ext-a", Position: model.Position{Filename: "/Users/me/go/pkg/mod/example.com/lib/a.go"}},
+				{ID: "ext-b", Position: model.Position{Filename: "/Users/me/go/pkg/mod/example.com/lib/b.go"}},
+			},
+			Edges: []model.CallGraphEdge{
+				{ID: "drop-edge", SourceID: "ext-a", TargetID: "ext-b"},
+				{ID: "keep-edge", SourceID: "local", TargetID: "ext-a"},
+			},
+		},
+		DataFlow: &model.DataFlowEvidence{
+			Nodes: []model.DataFlowNode{
+				{ID: "local-node", Position: model.Position{Filename: "/workspace/service/main.go"}, Source: true},
+				{ID: "local-sink", Position: model.Position{Filename: "/workspace/service/main.go"}, Sink: true},
+				{ID: "ext-src", Position: model.Position{Filename: "/Users/me/go/pkg/mod/example.com/lib/a.go"}, Source: true},
+				{ID: "ext-sink", Position: model.Position{Filename: "/Users/me/go/pkg/mod/example.com/lib/b.go"}, Sink: true},
+			},
+			Edges: []model.DataFlowEdge{{ID: "local-edge"}, {ID: "ext-edge"}},
+			Slices: []model.DataFlowSlice{
+				{ID: "keep-slice", SourceID: "local-node", SinkID: "local-sink", NodeIDs: []string{"local-node", "local-sink"}, EdgeIDs: []string{"local-edge"}, FlowKey: "local"},
+				{ID: "drop-slice", SourceID: "ext-src", SinkID: "ext-sink", NodeIDs: []string{"ext-src", "ext-sink"}, EdgeIDs: []string{"ext-edge"}, FlowKey: "ext"},
+			},
+		},
+	}
+	filterExternalOnlyModuleCacheFlows(report, false)
+	if len(report.CallGraph.Edges) != 1 || report.CallGraph.Edges[0].ID != "keep-edge" {
+		t.Fatalf("expected only mixed callgraph edge to remain, got %#v", report.CallGraph.Edges)
+	}
+	if len(report.DataFlow.Slices) != 1 || report.DataFlow.Slices[0].ID != "keep-slice" {
+		t.Fatalf("expected only non-cache dataflow slice to remain, got %#v", report.DataFlow.Slices)
+	}
+
+	includeAll := &model.Report{CallGraph: &model.CallGraph{Nodes: report.CallGraph.Nodes, Edges: []model.CallGraphEdge{{ID: "ext-only", SourceID: "ext-a", TargetID: "ext-b"}}}}
+	filterExternalOnlyModuleCacheFlows(includeAll, true)
+	if len(includeAll.CallGraph.Edges) != 1 {
+		t.Fatalf("expected include-all-flows to keep edges, got %#v", includeAll.CallGraph.Edges)
 	}
 }
 

--- a/thirdparty/golem/internal/analyzer/dataflow.go
+++ b/thirdparty/golem/internal/analyzer/dataflow.go
@@ -450,12 +450,12 @@ func builtinDataFlowPatterns(packs []string) *model.DataFlowPatternSet {
 		for _, name := range []string{"fmt.Sprintf", "fmt.Sprint", "fmt.Sprintln", "strings.Join", "strings.Trim", "strings.TrimSpace", "strings.Replace", "strings.ReplaceAll", "bytes.(*Buffer).String", "strconv.Itoa", "strconv.Format", "net/url.QueryEscape", "net/url.PathEscape", "net/url.JoinPath", "reflect.ValueOf", "reflect.Value.Interface", "reflect.Value).Interface", "reflect.Value.String", "reflect.Value).String", "reflect.Value.Bytes", "reflect.Value).Bytes", "reflect.Value.Convert", "reflect.Value).Convert"} {
 			addPass("function", name, "conversion")
 		}
-		for _, name := range []string{"log.Print", "log.Printf", "log.Println", "log.Fatal", "log.Fatalf", "log.Fatalln", "log.Panic", "log.Panicf", "log.Panicln", "log/slog.Debug", "log/slog.Info", "log/slog.Warn", "log/slog.Error", "fmt.Print", "fmt.Printf", "fmt.Println", "fmt.Fprint", "fmt.Fprintf", "fmt.Fprintln"} {
+		for _, name := range []string{"log.Print", "log.Printf", "log.Println", "log.Fatal", "log.Fatalf", "log.Fatalln", "log.Panic", "log.Panicf", "log.Panicln", "log/slog.Debug", "log/slog.Info", "log/slog.Warn", "log/slog.Error", "go.uber.org/zap.(*Logger).Info", "go.uber.org/zap.(*Logger).Warn", "go.uber.org/zap.(*Logger).Error", "go.uber.org/zap.(*SugaredLogger).Info", "go.uber.org/zap.(*SugaredLogger).Infof", "go.uber.org/zap.(*SugaredLogger).Error", "fmt.Print", "fmt.Printf", "fmt.Println", "fmt.Fprint", "fmt.Fprintf", "fmt.Fprintln"} {
 			addSink("function", name, "logging", "user-input", "secret")
 		}
 	}
 	if selected["http"] {
-		for _, name := range []string{"FormValue", "PostFormValue", "Cookie", "Header.Get", "Header).Get", "Values.Get", "(*net/url.URL).Query", "ParseForm", "MultipartReader", "FormFile", "github.com/gin-gonic/gin", "Param", "PostForm", "DefaultQuery", "GetHeader", "Bind", "BindJSON", "ShouldBind", "ShouldBindJSON", "github.com/labstack/echo", "QueryParam", "Param", "FormValue", "Bind", "github.com/gofiber/fiber", "Params", "Body", "BodyRaw", "BodyParser", "Cookies"} {
+		for _, name := range []string{"FormValue", "PostFormValue", "Cookie", "Header.Get", "Header).Get", "Values.Get", "(*net/url.URL).Query", "ParseForm", "MultipartReader", "FormFile", "github.com/gin-gonic/gin", "Param", "PostForm", "DefaultQuery", "GetHeader", "Bind", "BindJSON", "ShouldBind", "ShouldBindJSON", "github.com/labstack/echo", "QueryParam", "Param", "FormValue", "Bind", "github.com/gofiber/fiber", "Params", "Body", "BodyRaw", "BodyParser", "Cookies", "github.com/gorilla/mux.Vars", "github.com/go-chi/chi.URLParam", "github.com/go-chi/chi.URLParamFromCtx", "google.golang.org/grpc/metadata.FromIncomingContext", "google.golang.org/grpc.(*ServerStream).RecvMsg"} {
 			addSource("function", name, "http-input", "user-input")
 		}
 		addSink("function", "net/http.ResponseWriter.Write", "http-response", "user-input")
@@ -527,6 +527,9 @@ func builtinDataFlowPatterns(packs []string) *model.DataFlowPatternSet {
 	if selected["cloud"] {
 		for _, name := range []string{"github.com/aws/aws-sdk-go", "github.com/aws/aws-sdk-go-v2", "cloud.google.com/go", "google.golang.org/api", "github.com/Azure/azure-sdk-for-go"} {
 			addSink("package", name, "external-service", "user-input", "secret")
+		}
+		for _, name := range []string{"net/http.(*Client).Do", "google.golang.org/grpc.(*ClientConn).Invoke", "google.golang.org/grpc.(*ClientConn).NewStream", "google.golang.org/grpc.ClientStream.SendMsg", "google.golang.org/grpc.ClientStream.RecvMsg"} {
+			addSink("function", name, "external-service", "user-input", "secret")
 		}
 	}
 	set.Sources = normalizePatterns("source", set.Sources)

--- a/thirdparty/golem/internal/analyzer/flow_filter.go
+++ b/thirdparty/golem/internal/analyzer/flow_filter.go
@@ -1,0 +1,167 @@
+package analyzer
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cdxgen/cdxgen-plugins-bin/thirdparty/golem/internal/model"
+)
+
+func filterExternalOnlyModuleCacheFlows(report *model.Report, includeAllFlows bool) {
+	if report == nil || includeAllFlows {
+		return
+	}
+	if report.CallGraph != nil {
+		filterCallGraphModuleCacheFlows(report.CallGraph)
+	}
+	if report.DataFlow != nil {
+		filterDataFlowModuleCacheFlows(report.DataFlow)
+	}
+}
+
+func filterCallGraphModuleCacheFlows(cg *model.CallGraph) {
+	if cg == nil {
+		return
+	}
+	cacheNode := map[string]bool{}
+	for _, node := range cg.Nodes {
+		cacheNode[node.ID] = callGraphNodeFromModuleCache(node)
+	}
+	keptEdges := make([]model.CallGraphEdge, 0, len(cg.Edges))
+	referenced := map[string]bool{}
+	for _, edge := range cg.Edges {
+		if cacheNode[edge.SourceID] && cacheNode[edge.TargetID] {
+			continue
+		}
+		keptEdges = append(keptEdges, edge)
+		referenced[edge.SourceID] = true
+		referenced[edge.TargetID] = true
+	}
+	keptNodes := make([]model.CallGraphNode, 0, len(cg.Nodes))
+	for _, node := range cg.Nodes {
+		if cacheNode[node.ID] && !referenced[node.ID] {
+			continue
+		}
+		keptNodes = append(keptNodes, node)
+	}
+	cg.Nodes = keptNodes
+	cg.Edges = keptEdges
+	cg.Stats.NodeCount = len(cg.Nodes)
+	cg.Stats.EdgeCount = len(cg.Edges)
+	sort.Slice(cg.Nodes, func(i, j int) bool { return cg.Nodes[i].ID < cg.Nodes[j].ID })
+	sort.Slice(cg.Edges, func(i, j int) bool { return cg.Edges[i].ID < cg.Edges[j].ID })
+}
+
+func filterDataFlowModuleCacheFlows(df *model.DataFlowEvidence) {
+	if df == nil {
+		return
+	}
+	cacheNode := map[string]bool{}
+	for _, node := range df.Nodes {
+		cacheNode[node.ID] = dataFlowNodeFromModuleCache(node)
+	}
+	keptSlices := make([]model.DataFlowSlice, 0, len(df.Slices))
+	removed := 0
+	for _, slice := range df.Slices {
+		if dataFlowSliceAllInModuleCache(slice, cacheNode) {
+			removed++
+			continue
+		}
+		keptSlices = append(keptSlices, slice)
+	}
+	if removed == 0 {
+		return
+	}
+	df.Slices = keptSlices
+	recomputeDataFlowStats(df)
+	sortDataFlowEvidence(df)
+}
+
+func dataFlowSliceAllInModuleCache(slice model.DataFlowSlice, cacheNodes map[string]bool) bool {
+	nodeIDs := append([]string{}, slice.NodeIDs...)
+	nodeIDs = append(nodeIDs, slice.SourceID, slice.SinkID)
+	found := false
+	for _, nodeID := range nodeIDs {
+		if strings.TrimSpace(nodeID) == "" {
+			continue
+		}
+		found = true
+		if !cacheNodes[nodeID] {
+			return false
+		}
+	}
+	return found
+}
+
+func recomputeDataFlowStats(df *model.DataFlowEvidence) {
+	if df == nil {
+		return
+	}
+	df.Stats.NodeCount = len(df.Nodes)
+	df.Stats.EdgeCount = len(df.Edges)
+	df.Stats.SliceCount = len(df.Slices)
+	df.Stats.SourceCount = 0
+	df.Stats.SinkCount = 0
+	df.Stats.UniqueFlowCount = 0
+	df.Stats.DuplicateSliceCount = 0
+	df.Stats.DuplicateGroupCount = 0
+	df.Stats.MaxPathLength = 0
+	df.Stats.AveragePathLength = 0
+	df.Stats.SanitizedSliceCount = 0
+	for _, node := range df.Nodes {
+		if node.Source {
+			df.Stats.SourceCount++
+		}
+		if node.Sink {
+			df.Stats.SinkCount++
+		}
+	}
+	if len(df.Slices) == 0 {
+		return
+	}
+	countByFlow := map[string]int{}
+	totalPath := 0
+	for _, slice := range df.Slices {
+		if slice.FlowKey != "" {
+			countByFlow[slice.FlowKey]++
+		}
+		if slice.PathLength > df.Stats.MaxPathLength {
+			df.Stats.MaxPathLength = slice.PathLength
+		}
+		totalPath += slice.PathLength
+		if len(slice.SanitizerNodeIDs) > 0 {
+			df.Stats.SanitizedSliceCount++
+		}
+	}
+	df.Stats.UniqueFlowCount = len(countByFlow)
+	for _, count := range countByFlow {
+		if count > 1 {
+			df.Stats.DuplicateSliceCount += count - 1
+			df.Stats.DuplicateGroupCount++
+		}
+	}
+	df.Stats.AveragePathLength = float64(totalPath) / float64(len(df.Slices))
+}
+
+func callGraphNodeFromModuleCache(node model.CallGraphNode) bool {
+	if isGoModuleCachePath(node.Position.Filename) {
+		return true
+	}
+	return node.Module != nil && isGoModuleCachePath(node.Module.Dir)
+}
+
+func dataFlowNodeFromModuleCache(node model.DataFlowNode) bool {
+	if isGoModuleCachePath(node.Position.Filename) {
+		return true
+	}
+	return node.Module != nil && isGoModuleCachePath(node.Module.Dir)
+}
+
+func isGoModuleCachePath(path string) bool {
+	normalized := strings.ToLower(filepath.ToSlash(strings.TrimSpace(path)))
+	if normalized == "" {
+		return false
+	}
+	return strings.Contains(normalized, "/go/pkg/mod/") || strings.Contains(normalized, "/pkg/mod/")
+}

--- a/thirdparty/golem/internal/analyzer/multimodule.go
+++ b/thirdparty/golem/internal/analyzer/multimodule.go
@@ -1,0 +1,251 @@
+package analyzer
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cdxgen/cdxgen-plugins-bin/thirdparty/golem/internal/model"
+)
+
+func analyzeAcrossChildModules(options Options, absDir string, progress *progressLogger) (*model.Report, bool, error) {
+	if options.NoRecurse || directoryHasGoModuleRoot(absDir) {
+		return nil, false, nil
+	}
+	moduleDirs, err := discoverChildGoModuleDirs(absDir)
+	if err != nil {
+		return nil, true, err
+	}
+	if len(moduleDirs) == 0 {
+		return nil, false, nil
+	}
+	progress.Logf("root has no go.mod/go.work; recursing into %d child modules", len(moduleDirs))
+	var merged *model.Report
+	var failures []string
+	for _, moduleDir := range moduleDirs {
+		child := options
+		child.Dir = moduleDir
+		child.NoRecurse = true
+		report, err := Analyze(child)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", moduleDir, err))
+			continue
+		}
+		if merged == nil {
+			merged = report
+			continue
+		}
+		mergeReports(merged, report)
+	}
+	if merged == nil {
+		if len(failures) > 0 {
+			return nil, true, fmt.Errorf("failed to analyze discovered modules: %s", strings.Join(failures, "; "))
+		}
+		return nil, true, fmt.Errorf("no analyzable child modules found under %s", absDir)
+	}
+	for _, failure := range failures {
+		merged.Diagnostics = append(merged.Diagnostics, model.Diagnostic{Kind: "recurse", Message: failure})
+	}
+	merged.Runtime.WorkingDir = absDir
+	merged.Runtime.Patterns = append([]string{}, options.Patterns...)
+	merged.Runtime.BuildTags = append([]string{}, options.BuildTags...)
+	merged.Runtime.Tests = options.Tests
+	merged.Options.Directory = absDir
+	merged.Options.NoRecurse = options.NoRecurse
+	merged.Options.IncludeAllFlows = options.IncludeAllFlows
+	merged.Options.Patterns = append([]string{}, options.Patterns...)
+	merged.Options.BuildTags = append([]string{}, options.BuildTags...)
+	merged.Options.Tests = options.Tests
+	merged.Options.IncludeStdlib = options.IncludeStdlib
+	merged.Options.IncludeLocal = options.IncludeLocal
+	merged.Options.CallGraphMode = options.CallGraphMode
+	merged.Options.DataFlowMode = options.DataFlowMode
+	merged.Options.DataFlowCallGraphMode = options.DataFlowCallGraphMode
+	filterExternalOnlyModuleCacheFlows(merged, options.IncludeAllFlows)
+	a := &Analyzer{}
+	a.populateStats(merged)
+	sortReport(merged)
+	return merged, true, nil
+}
+
+func directoryHasGoModuleRoot(dir string) bool {
+	if dir == "" {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+		return true
+	}
+	if _, err := os.Stat(filepath.Join(dir, "go.work")); err == nil {
+		return true
+	}
+	return false
+}
+
+func discoverChildGoModuleDirs(root string) ([]string, error) {
+	var dirs []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "vendor", "node_modules":
+				return filepath.SkipDir
+			}
+			if strings.HasPrefix(d.Name(), ".") && path != root {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == "go.mod" {
+			dirs = append(dirs, filepath.Dir(path))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(dirs) == 0 {
+		return nil, nil
+	}
+	sort.Strings(dirs)
+	out := dirs[:0]
+	for _, dir := range dirs {
+		if len(out) == 0 || out[len(out)-1] != dir {
+			out = append(out, dir)
+		}
+	}
+	return out, nil
+}
+func mergeReports(dst *model.Report, src *model.Report) {
+	if dst == nil || src == nil {
+		return
+	}
+	dst.RootModules = append(dst.RootModules, src.RootModules...)
+	dst.Modules = append(dst.Modules, src.Modules...)
+	dst.Packages = append(dst.Packages, src.Packages...)
+	dst.Files = append(dst.Files, src.Files...)
+	dst.Imports = append(dst.Imports, src.Imports...)
+	dst.Declarations = append(dst.Declarations, src.Declarations...)
+	dst.Usages = append(dst.Usages, src.Usages...)
+	dst.BuildDirectives = append(dst.BuildDirectives, src.BuildDirectives...)
+	dst.NativeArtifacts = append(dst.NativeArtifacts, src.NativeArtifacts...)
+	dst.APIEndpoints = dedupeEndpoints(append(dst.APIEndpoints, src.APIEndpoints...))
+	dst.ExternalURLs = dedupeExternalURLs(append(dst.ExternalURLs, src.ExternalURLs...))
+	dst.Services = append(dst.Services, src.Services...)
+	dst.SecuritySignals = dedupeSignals(append(dst.SecuritySignals, src.SecuritySignals...))
+	dst.Crypto = mergeCryptoEvidence(dst.Crypto, src.Crypto)
+	dst.Diagnostics = append(dst.Diagnostics, src.Diagnostics...)
+	if src.CallGraph != nil {
+		if dst.CallGraph == nil {
+			dst.CallGraph = src.CallGraph
+		} else {
+			dst.CallGraph.Nodes = appendUniqueCallGraphNodes(dst.CallGraph.Nodes, src.CallGraph.Nodes)
+			dst.CallGraph.Edges = appendUniqueCallGraphEdges(dst.CallGraph.Edges, src.CallGraph.Edges)
+			dst.CallGraph.Diagnostics = append(dst.CallGraph.Diagnostics, src.CallGraph.Diagnostics...)
+			dst.CallGraph.Stats.NodeCount = len(dst.CallGraph.Nodes)
+			dst.CallGraph.Stats.EdgeCount = len(dst.CallGraph.Edges)
+		}
+	}
+	if src.DataFlow != nil {
+		if dst.DataFlow == nil {
+			dst.DataFlow = src.DataFlow
+		} else {
+			dst.DataFlow.Nodes = appendUniqueDataFlowNodes(dst.DataFlow.Nodes, src.DataFlow.Nodes)
+			dst.DataFlow.Edges = appendUniqueDataFlowEdges(dst.DataFlow.Edges, src.DataFlow.Edges)
+			dst.DataFlow.Slices = appendUniqueDataFlowSlices(dst.DataFlow.Slices, src.DataFlow.Slices)
+			dst.DataFlow.Summaries = appendUniqueDataFlowSummaries(dst.DataFlow.Summaries, src.DataFlow.Summaries)
+			dst.DataFlow.Diagnostics = append(dst.DataFlow.Diagnostics, src.DataFlow.Diagnostics...)
+			dst.DataFlow.Stats.NodeCount = len(dst.DataFlow.Nodes)
+			dst.DataFlow.Stats.EdgeCount = len(dst.DataFlow.Edges)
+			dst.DataFlow.Stats.SliceCount = len(dst.DataFlow.Slices)
+		}
+	}
+}
+
+func appendUniqueCallGraphNodes(dst, src []model.CallGraphNode) []model.CallGraphNode {
+	seen := map[string]bool{}
+	for _, node := range dst {
+		seen[node.ID] = true
+	}
+	for _, node := range src {
+		if !seen[node.ID] {
+			seen[node.ID] = true
+			dst = append(dst, node)
+		}
+	}
+	return dst
+}
+
+func appendUniqueCallGraphEdges(dst, src []model.CallGraphEdge) []model.CallGraphEdge {
+	seen := map[string]bool{}
+	for _, edge := range dst {
+		seen[edge.ID] = true
+	}
+	for _, edge := range src {
+		if !seen[edge.ID] {
+			seen[edge.ID] = true
+			dst = append(dst, edge)
+		}
+	}
+	return dst
+}
+
+func appendUniqueDataFlowNodes(dst, src []model.DataFlowNode) []model.DataFlowNode {
+	seen := map[string]bool{}
+	for _, node := range dst {
+		seen[node.ID] = true
+	}
+	for _, node := range src {
+		if !seen[node.ID] {
+			seen[node.ID] = true
+			dst = append(dst, node)
+		}
+	}
+	return dst
+}
+
+func appendUniqueDataFlowEdges(dst, src []model.DataFlowEdge) []model.DataFlowEdge {
+	seen := map[string]bool{}
+	for _, edge := range dst {
+		seen[edge.ID] = true
+	}
+	for _, edge := range src {
+		if !seen[edge.ID] {
+			seen[edge.ID] = true
+			dst = append(dst, edge)
+		}
+	}
+	return dst
+}
+
+func appendUniqueDataFlowSlices(dst, src []model.DataFlowSlice) []model.DataFlowSlice {
+	seen := map[string]bool{}
+	for _, slice := range dst {
+		seen[slice.ID] = true
+	}
+	for _, slice := range src {
+		if !seen[slice.ID] {
+			seen[slice.ID] = true
+			dst = append(dst, slice)
+		}
+	}
+	return dst
+}
+
+func appendUniqueDataFlowSummaries(dst, src []model.DataFlowMethodSummary) []model.DataFlowMethodSummary {
+	seen := map[string]bool{}
+	for _, summary := range dst {
+		seen[summary.FunctionID] = true
+	}
+	for _, summary := range src {
+		if !seen[summary.FunctionID] {
+			seen[summary.FunctionID] = true
+			dst = append(dst, summary)
+		}
+	}
+	return dst
+}

--- a/thirdparty/golem/internal/analyzer/multimodule.go
+++ b/thirdparty/golem/internal/analyzer/multimodule.go
@@ -138,6 +138,7 @@ func mergeReports(dst *model.Report, src *model.Report) {
 	dst.Services = append(dst.Services, src.Services...)
 	dst.SecuritySignals = dedupeSignals(append(dst.SecuritySignals, src.SecuritySignals...))
 	dst.Crypto = mergeCryptoEvidence(dst.Crypto, src.Crypto)
+	dst.SupplyChain = mergeSupplyChainEvidence(dst.SupplyChain, src.SupplyChain)
 	dst.Diagnostics = append(dst.Diagnostics, src.Diagnostics...)
 	if src.CallGraph != nil {
 		if dst.CallGraph == nil {
@@ -154,16 +155,132 @@ func mergeReports(dst *model.Report, src *model.Report) {
 		if dst.DataFlow == nil {
 			dst.DataFlow = src.DataFlow
 		} else {
+			mergeDataFlowAggregateStats(&dst.DataFlow.Stats, src.DataFlow.Stats)
 			dst.DataFlow.Nodes = appendUniqueDataFlowNodes(dst.DataFlow.Nodes, src.DataFlow.Nodes)
 			dst.DataFlow.Edges = appendUniqueDataFlowEdges(dst.DataFlow.Edges, src.DataFlow.Edges)
 			dst.DataFlow.Slices = appendUniqueDataFlowSlices(dst.DataFlow.Slices, src.DataFlow.Slices)
 			dst.DataFlow.Summaries = appendUniqueDataFlowSummaries(dst.DataFlow.Summaries, src.DataFlow.Summaries)
+			if dst.DataFlow.Patterns == nil {
+				dst.DataFlow.Patterns = src.DataFlow.Patterns
+			}
 			dst.DataFlow.Diagnostics = append(dst.DataFlow.Diagnostics, src.DataFlow.Diagnostics...)
-			dst.DataFlow.Stats.NodeCount = len(dst.DataFlow.Nodes)
-			dst.DataFlow.Stats.EdgeCount = len(dst.DataFlow.Edges)
-			dst.DataFlow.Stats.SliceCount = len(dst.DataFlow.Slices)
+			recomputeDataFlowStats(dst.DataFlow)
+			dst.DataFlow.Stats.SummaryCount = len(dst.DataFlow.Summaries)
+			dst.DataFlow.Stats.TruncationReasons = dataFlowTruncationReasons(dst.DataFlow.Diagnostics)
+			dst.DataFlow.Stats.Truncated = len(dst.DataFlow.Stats.TruncationReasons) > 0
 		}
 	}
+}
+
+func mergeDataFlowAggregateStats(dst *model.DataFlowStats, src model.DataFlowStats) {
+	if dst == nil {
+		return
+	}
+	dst.CandidateFunctionCount += src.CandidateFunctionCount
+	dst.FunctionCount += src.FunctionCount
+	dst.SkippedFunctionCount += src.SkippedFunctionCount
+	dst.InstructionCount += src.InstructionCount
+	dst.ElapsedMillis += src.ElapsedMillis
+	if src.WorkerCount > dst.WorkerCount {
+		dst.WorkerCount = src.WorkerCount
+	}
+}
+
+func mergeSupplyChainEvidence(dst *model.SupplyChainEvidence, src *model.SupplyChainEvidence) *model.SupplyChainEvidence {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		copied := *src
+		copied.Replaces = append([]model.GoModDirective{}, src.Replaces...)
+		copied.Excludes = append([]model.GoModDirective{}, src.Excludes...)
+		copied.Modules = append([]model.ModuleCompliance{}, src.Modules...)
+		if src.Properties != nil {
+			copied.Properties = map[string]string{}
+			for key, value := range src.Properties {
+				copied.Properties[key] = value
+			}
+		}
+		return &copied
+	}
+	dst.GoDirectiveVersion = firstNonEmpty(dst.GoDirectiveVersion, src.GoDirectiveVersion)
+	dst.ToolchainDirective = firstNonEmpty(dst.ToolchainDirective, src.ToolchainDirective)
+	dst.GoWorkPresent = dst.GoWorkPresent || src.GoWorkPresent
+	dst.VendorDirectoryPresent = dst.VendorDirectoryPresent || src.VendorDirectoryPresent
+	dst.Replaces = appendUniqueGoModDirectives(dst.Replaces, src.Replaces)
+	dst.Excludes = appendUniqueGoModDirectives(dst.Excludes, src.Excludes)
+	dst.Modules = appendUniqueModuleCompliance(dst.Modules, src.Modules)
+	dst.WorkspaceModuleCount = countWorkspaceModules(dst.Modules)
+	dst.VendorModuleCount = countVendoredModules(dst.Modules)
+	if dst.Properties == nil {
+		dst.Properties = map[string]string{}
+	}
+	for key, value := range src.Properties {
+		if _, ok := dst.Properties[key]; !ok {
+			dst.Properties[key] = value
+		}
+	}
+	return dst
+}
+
+func appendUniqueGoModDirectives(dst, src []model.GoModDirective) []model.GoModDirective {
+	seen := map[string]bool{}
+	for _, directive := range dst {
+		seen[goModDirectiveKey(directive)] = true
+	}
+	for _, directive := range src {
+		key := goModDirectiveKey(directive)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		dst = append(dst, directive)
+	}
+	return dst
+}
+
+func goModDirectiveKey(d model.GoModDirective) string {
+	return strings.Join([]string{d.Kind, d.ModulePath, d.Version, d.TargetModulePath, d.TargetVersion, d.Source}, "\x00")
+}
+
+func appendUniqueModuleCompliance(dst, src []model.ModuleCompliance) []model.ModuleCompliance {
+	seen := map[string]bool{}
+	for _, module := range dst {
+		seen[moduleComplianceKey(module)] = true
+	}
+	for _, module := range src {
+		key := moduleComplianceKey(module)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		dst = append(dst, module)
+	}
+	return dst
+}
+
+func moduleComplianceKey(module model.ModuleCompliance) string {
+	return strings.Join([]string{module.Path, module.Version, module.PURL}, "\x00")
+}
+
+func countWorkspaceModules(modules []model.ModuleCompliance) int {
+	count := 0
+	for _, module := range modules {
+		if module.Main {
+			count++
+		}
+	}
+	return count
+}
+
+func countVendoredModules(modules []model.ModuleCompliance) int {
+	count := 0
+	for _, module := range modules {
+		if module.Vendored {
+			count++
+		}
+	}
+	return count
 }
 
 func appendUniqueCallGraphNodes(dst, src []model.CallGraphNode) []model.CallGraphNode {

--- a/thirdparty/golem/internal/analyzer/options.go
+++ b/thirdparty/golem/internal/analyzer/options.go
@@ -10,10 +10,12 @@ import (
 	"github.com/cdxgen/cdxgen-plugins-bin/thirdparty/golem/internal/model"
 )
 
-const SchemaVersion = "https://cyclonedx.github.io/cdxgen/golem/schema/v1"
+const SchemaVersion = "https://cdxgen.github.io/cdxgen-plugins-bin/golem/schema/v1"
 
 type Options struct {
 	Dir                             string
+	NoRecurse                       bool
+	IncludeAllFlows                 bool
 	Patterns                        []string
 	BuildTags                       []string
 	Tests                           bool

--- a/thirdparty/golem/internal/analyzer/report.go
+++ b/thirdparty/golem/internal/analyzer/report.go
@@ -29,6 +29,9 @@ func Analyze(options Options) (*model.Report, error) {
 	if len(options.Patterns) == 0 {
 		options.Patterns = []string{"./..."}
 	}
+	if merged, ok, err := analyzeAcrossChildModules(options, absDir, progress); ok {
+		return merged, err
+	}
 	if options.CallGraphMode == "" {
 		options.CallGraphMode = "none"
 	}
@@ -97,6 +100,8 @@ func Analyze(options Options) (*model.Report, error) {
 		},
 		Options: model.AnalysisOptions{
 			Directory:                       absDir,
+			NoRecurse:                       options.NoRecurse,
+			IncludeAllFlows:                 options.IncludeAllFlows,
 			Patterns:                        append([]string{}, options.Patterns...),
 			BuildTags:                       append([]string{}, options.BuildTags...),
 			Tests:                           options.Tests,
@@ -156,6 +161,7 @@ func Analyze(options Options) (*model.Report, error) {
 	if options.DataFlowMode != "none" {
 		report.DataFlow = a.buildDataFlow(pkgs, ssaCtx, progress)
 	}
+	filterExternalOnlyModuleCacheFlows(report, options.IncludeAllFlows)
 	a.populateStats(report)
 	sortReport(report)
 	progress.Memoryf("analysis complete")

--- a/thirdparty/golem/internal/analyzer/report.go
+++ b/thirdparty/golem/internal/analyzer/report.go
@@ -29,9 +29,6 @@ func Analyze(options Options) (*model.Report, error) {
 	if len(options.Patterns) == 0 {
 		options.Patterns = []string{"./..."}
 	}
-	if merged, ok, err := analyzeAcrossChildModules(options, absDir, progress); ok {
-		return merged, err
-	}
 	if options.CallGraphMode == "" {
 		options.CallGraphMode = "none"
 	}
@@ -46,6 +43,9 @@ func Analyze(options Options) (*model.Report, error) {
 	options.DataFlowCallGraphMode = strings.ToLower(strings.TrimSpace(options.DataFlowCallGraphMode))
 	if options.DataFlowMax <= 0 {
 		options.DataFlowMax = 1000
+	}
+	if merged, ok, err := analyzeAcrossChildModules(options, absDir, progress); ok {
+		return merged, err
 	}
 	progress.Logf("analysis starting dir=%s patterns=%s maxProcs=%d workers=%d memoryLimit=%s", options.Dir, strings.Join(options.Patterns, ","), runtime.GOMAXPROCS(0), dataFlowWorkerCount(options, 0), formatBytes(options.MemoryLimit))
 

--- a/thirdparty/golem/internal/exporter/exporter.go
+++ b/thirdparty/golem/internal/exporter/exporter.go
@@ -61,7 +61,6 @@ func Write(w io.Writer, report *model.Report, format Format) error {
 	case FormatJSON:
 		enc := json.NewEncoder(w)
 		enc.SetEscapeHTML(false)
-		enc.SetIndent("", "  ")
 		return enc.Encode(report)
 	case FormatGraphML:
 		_, err := io.WriteString(w, GraphML(report.CallGraph))

--- a/thirdparty/golem/internal/exporter/exporter_test.go
+++ b/thirdparty/golem/internal/exporter/exporter_test.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -16,5 +17,20 @@ func TestGraphExportsEscapeXML(t *testing.T) {
 	gexf := GEXF(graph)
 	if strings.Contains(gexf, "a&b") || !strings.Contains(gexf, "a&amp;b") {
 		t.Fatalf("gexf did not escape id: %s", gexf)
+	}
+}
+
+func TestWriteJSONIsMinifiedByDefault(t *testing.T) {
+	var out bytes.Buffer
+	report := &model.Report{SchemaVersion: "test", Tool: model.ToolInfo{Name: "golem", Version: "test"}, Runtime: model.RuntimeInfo{}, Options: model.AnalysisOptions{}, Stats: model.Stats{}}
+	if err := Write(&out, report, FormatJSON); err != nil {
+		t.Fatal(err)
+	}
+	text := out.String()
+	if strings.Contains(text, "\n  \"") {
+		t.Fatalf("expected compact json output without indentation, got %q", text)
+	}
+	if !strings.HasPrefix(text, "{\"") {
+		t.Fatalf("expected compact json output, got %q", text)
 	}
 }

--- a/thirdparty/golem/internal/model/model.go
+++ b/thirdparty/golem/internal/model/model.go
@@ -27,8 +27,8 @@ type RuntimeInfo struct {
 }
 type AnalysisOptions struct {
 	Directory                       string   `json:"directory"`
-	NoRecurse                       bool     `json:"noRecurse,omitempty"`
-	IncludeAllFlows                 bool     `json:"includeAllFlows,omitempty"`
+	NoRecurse                       bool     `json:"noRecurse"`
+	IncludeAllFlows                 bool     `json:"includeAllFlows"`
 	Patterns                        []string `json:"patterns"`
 	BuildTags                       []string `json:"buildTags,omitempty"`
 	Tests                           bool     `json:"tests"`

--- a/thirdparty/golem/internal/model/model.go
+++ b/thirdparty/golem/internal/model/model.go
@@ -27,6 +27,8 @@ type RuntimeInfo struct {
 }
 type AnalysisOptions struct {
 	Directory                       string   `json:"directory"`
+	NoRecurse                       bool     `json:"noRecurse,omitempty"`
+	IncludeAllFlows                 bool     `json:"includeAllFlows,omitempty"`
 	Patterns                        []string `json:"patterns"`
 	BuildTags                       []string `json:"buildTags,omitempty"`
 	Tests                           bool     `json:"tests"`


### PR DESCRIPTION
…d update JSON reference

- Add automatic discovery and merging of child Go modules when root has no go.mod/go.work (with --no-recurse to disable)
- Filter out call graph edges and data-flow slices rooted only in external module cache paths by default; add --include-all-flows to retain them
- Extend CLI options and JSON schema to support new behaviors
- Update docs and add JSON_ATTRIBUTE_REFERENCE.md for field-level report documentation
- Bump version to 2.2.2