### PR TITLE
Include trivy gobinary analysis

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
         cache: false
     - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a  # v2.4.0
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
     - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
     - run: oras version
     - name: Authenticate to GHCR

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,9 @@ jobs:
         python-version: '3.13'
     - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a  # v2.4.0
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
     - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
     - run: oras version
     - name: Trim CI agent
@@ -43,6 +43,7 @@ jobs:
         ./contrib/free_disk_space.sh
     - name: Run packaging helper tests
       run: |
+        bash ./scripts/assert-trivy-cdxgen-sbom.test.sh
         bash ./scripts/thirdparty-downloads.test.sh
         bash ./scripts/stage-built-plugins.test.sh
         bash ./scripts/publish-helper-oras.test.sh

--- a/.github/workflows/trivy-cdxgen-sbom-e2e.yml
+++ b/.github/workflows/trivy-cdxgen-sbom-e2e.yml
@@ -1,0 +1,89 @@
+name: trivy-cdxgen SBOM E2E
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  rootfs-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image_name: golang-alpine
+            image_ref: docker.io/library/golang:1.25.0-alpine3.22
+          - image_name: caddy-alpine
+            image_ref: docker.io/library/caddy:2.10.2-alpine
+          - image_name: registry
+            image_ref: docker.io/library/registry:3.0.0
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '^1.25.6'
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.13'
+      - name: Build local trivy-cdxgen
+        working-directory: thirdparty/trivy
+        run: |
+          mkdir -p build
+          GOEXPERIMENT=jsonv2 go build -o build/trivy-cdxgen-local .
+      - name: Export image rootfs
+        env:
+          IMAGE_NAME: ${{ matrix.image_name }}
+          IMAGE_REF: ${{ matrix.image_ref }}
+        run: |
+          set -euo pipefail
+
+          workdir="${RUNNER_TEMP}/trivy-cdxgen/${IMAGE_NAME}"
+          rootfs_dir="$workdir/rootfs"
+          cid="trivy-cdxgen-${IMAGE_NAME}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          rm -rf "$workdir"
+          mkdir -p "$rootfs_dir"
+
+          docker pull --platform=linux/amd64 "$IMAGE_REF"
+          docker create --platform=linux/amd64 --name "$cid" "$IMAGE_REF" >/dev/null
+          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+          docker export "$cid" -o "$workdir/rootfs.tar"
+          tar -xf "$workdir/rootfs.tar" -C "$rootfs_dir"
+      - name: Generate CycloneDX SBOM from rootfs
+        env:
+          IMAGE_NAME: ${{ matrix.image_name }}
+        run: |
+          set -euo pipefail
+
+          workdir="${RUNNER_TEMP}/trivy-cdxgen/${IMAGE_NAME}"
+          thirdparty/trivy/build/trivy-cdxgen-local rootfs \
+            --debug \
+            --output "$workdir/sbom.cdx.json" \
+            "$workdir/rootfs"
+      - name: Assert OS and Go binary coverage
+        env:
+          IMAGE_NAME: ${{ matrix.image_name }}
+          IMAGE_REF: ${{ matrix.image_ref }}
+        run: |
+          set -euo pipefail
+
+          workdir="${RUNNER_TEMP}/trivy-cdxgen/${IMAGE_NAME}"
+          bash ./scripts/assert-trivy-cdxgen-sbom.sh "$workdir/sbom.cdx.json" "$IMAGE_REF"
+      - name: Upload SBOM artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-cdxgen-sbom-${{ matrix.image_name }}
+          path: ${{ runner.temp }}/trivy-cdxgen/${{ matrix.image_name }}/sbom.cdx.json
+          if-no-files-found: warn
+          retention-days: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdxgen/cdxgen-plugins-bin",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "Apache-2.0"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/darwin-amd64/package.json
+++ b/packages/darwin-amd64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-darwin-amd64",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Arm64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-darwin-arm64",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Arm64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/linux-amd64/package.json
+++ b/packages/linux-amd64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linux-amd64",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "linux amd64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/linux-arm/package.json
+++ b/packages/linux-arm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linux-arm",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Arm binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/linux-arm64/package.json
+++ b/packages/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linux-arm64",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Arm64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/linux-riscv64/package.json
+++ b/packages/linux-riscv64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linux-riscv64",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "RISC-V 64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/linuxmusl-amd64/package.json
+++ b/packages/linuxmusl-amd64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linuxmusl-amd64",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Linux musl amd64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/linuxmusl-arm64/package.json
+++ b/packages/linuxmusl-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linuxmusl-arm64",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Linux musl arm64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/ppc64/package.json
+++ b/packages/ppc64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-linux-ppc64",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "ppc64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/windows-amd64/package.json
+++ b/packages/windows-amd64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-windows-amd64",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Windows amd64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/packages/windows-arm64/package.json
+++ b/packages/windows-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdxgen/cdxgen-plugins-bin-windows-arm64",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Arm64 binary plugins to supercharge @cdxgen/cdxgen npm package",
   "main": "index.js",
   "repository": {

--- a/scripts/assert-trivy-cdxgen-sbom.sh
+++ b/scripts/assert-trivy-cdxgen-sbom.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 SBOM_JSON [LABEL]" >&2
+  exit 2
+fi
+
+sbom_json="$1"
+label="${2:-$sbom_json}"
+
+if [[ ! -f "$sbom_json" ]]; then
+  echo "SBOM file not found: $sbom_json" >&2
+  exit 1
+fi
+
+python3 - "$sbom_json" "$label" <<'PY'
+import json
+import sys
+
+sbom_path, label = sys.argv[1], sys.argv[2]
+
+with open(sbom_path, encoding="utf-8") as handle:
+    bom = json.load(handle)
+
+components = bom.get("components")
+if not isinstance(components, list):
+    print(f"SBOM for {label} does not contain a components array", file=sys.stderr)
+    sys.exit(1)
+
+
+def property_values(component, property_name):
+    values = []
+    for prop in component.get("properties") or []:
+        if not isinstance(prop, dict):
+            continue
+        if prop.get("name") != property_name:
+            continue
+        value = prop.get("value")
+        if value is not None:
+            values.append(str(value))
+    return values
+
+
+os_components = [component for component in components if component.get("type") == "operating-system"]
+
+go_binary_components = []
+golang_components = []
+for component in components:
+    purl = str(component.get("purl") or "")
+    pkg_types = set(property_values(component, "aquasecurity:trivy:PkgType"))
+    pkg_types.update(property_values(component, "PkgType"))
+    if purl.startswith("pkg:golang/"):
+        golang_components.append(component)
+    if "gobinary" in pkg_types:
+        go_binary_components.append(component)
+
+if not os_components:
+    print(f"SBOM for {label} did not contain any operating-system components", file=sys.stderr)
+    sys.exit(1)
+
+if not go_binary_components:
+    golang_sample = ", ".join(
+        str(component.get("name") or "<unnamed>") for component in golang_components[:5]
+    ) or "<none>"
+    print(
+        f"SBOM for {label} did not contain any Go binary components. "
+        f"Found {len(golang_components)} golang PURLs. Samples: {golang_sample}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+os_sample = ", ".join(str(component.get("name") or "<unnamed>") for component in os_components[:5])
+go_sample = ", ".join(str(component.get("name") or "<unnamed>") for component in go_binary_components[:5])
+print(
+    f"Validated SBOM for {label}: "
+    f"os_components={len(os_components)} go_binary_components={len(go_binary_components)}"
+)
+print(f"OS component samples: {os_sample}")
+print(f"Go binary samples: {go_sample}")
+PY

--- a/scripts/assert-trivy-cdxgen-sbom.test.sh
+++ b/scripts/assert-trivy-cdxgen-sbom.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_script="$script_dir/assert-trivy-cdxgen-sbom.sh"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat > "$tmpdir/good.json" <<'JSON'
+{
+  "components": [
+    {
+      "type": "operating-system",
+      "name": "alpine"
+    },
+    {
+      "type": "library",
+      "name": "github.com/example/demo",
+      "purl": "pkg:golang/github.com/example/demo@v1.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gobinary"
+        }
+      ]
+    }
+  ]
+}
+JSON
+
+bash "$helper_script" "$tmpdir/good.json" "good-fixture"
+
+cat > "$tmpdir/missing-os.json" <<'JSON'
+{
+  "components": [
+    {
+      "type": "library",
+      "name": "github.com/example/demo",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gobinary"
+        }
+      ]
+    }
+  ]
+}
+JSON
+
+if bash "$helper_script" "$tmpdir/missing-os.json" "missing-os" >"$tmpdir/missing-os.stdout" 2>"$tmpdir/missing-os.stderr"; then
+  echo "expected missing-os fixture to fail" >&2
+  exit 1
+fi
+grep -F "did not contain any operating-system components" "$tmpdir/missing-os.stderr" >/dev/null
+
+cat > "$tmpdir/missing-go.json" <<'JSON'
+{
+  "components": [
+    {
+      "type": "operating-system",
+      "name": "debian"
+    },
+    {
+      "type": "library",
+      "name": "github.com/example/demo",
+      "purl": "pkg:golang/github.com/example/demo@v1.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    }
+  ]
+}
+JSON
+
+if bash "$helper_script" "$tmpdir/missing-go.json" "missing-go" >"$tmpdir/missing-go.stdout" 2>"$tmpdir/missing-go.stderr"; then
+  echo "expected missing-go fixture to fail" >&2
+  exit 1
+fi
+grep -F "did not contain any Go binary components" "$tmpdir/missing-go.stderr" >/dev/null
+
+echo "trivy-cdxgen SBOM assertion helper test passed"

--- a/thirdparty/golem/Makefile
+++ b/thirdparty/golem/Makefile
@@ -1,6 +1,6 @@
 PATH := $(PATH):/usr/local/go/bin:$(HOME)/go/bin
 appname := golem
-version ?= 2.2.3
+version ?= 2.2.4
 sources := $(shell find cmd internal -type f -name '*.go')
 ldflags := -s -w -X main.version=$(version)
 

--- a/thirdparty/golem/cmd/golem/main.go
+++ b/thirdparty/golem/cmd/golem/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cdxgen/cdxgen-plugins-bin/thirdparty/golem/internal/exporter"
 )
 
-var version = "2.2.3"
+var version = "2.2.4"
 
 func main() {
 	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {

--- a/thirdparty/trivy/README.md
+++ b/thirdparty/trivy/README.md
@@ -9,7 +9,7 @@ Compared to the stock `cmd/trivy/main.go`, this wrapper is intentionally optimiz
 - exposes only the `image`, `rootfs`, and `version` commands
 - defaults `image`/`rootfs` scans to CycloneDX SBOM output
 - forces offline, no-update, no-progress operation
-- limits package collection to OS packages
+- limits language package collection to Go modules and Go binaries while still collecting OS packages
 - suppresses noisy output unless `--debug` is passed
 - enriches OS package components with:
   - package-manager capability/provide metadata
@@ -22,6 +22,50 @@ Compared to the stock `cmd/trivy/main.go`, this wrapper is intentionally optimiz
   - OS lifecycle metadata (`OSFamily`, `OSName`, `OSEOL`, `OSExtendedSupport`)
 
 When the wrapper output is consumed by `cdxgen`, maintainer/vendor trust metadata is further promoted into native CycloneDX component fields such as `authors` and `manufacturer` when that can be done without overwriting differing existing values.
+
+## Usage
+
+Build a local test binary from this directory:
+
+```bash
+GOEXPERIMENT=jsonv2 go build -o build/trivy-cdxgen-local .
+```
+
+Generate a CycloneDX SBOM from an unpacked root filesystem:
+
+```bash
+./build/trivy-cdxgen-local rootfs --output result.cdx.json /path/to/rootfs
+```
+
+The exact local command used during regression validation was:
+
+```bash
+./build/trivy-cdxgen-local rootfs --debug --output "$OUT" "$ROOTFS"
+```
+
+## Examples
+
+### Scan an exported image rootfs
+
+Pull the test image, export it with `docker`, unpack it, and run the local wrapper against the extracted rootfs:
+
+```bash
+docker pull alpine:latest
+CID="trivy-cdxgen-docker-test"
+ROOTFS="$(mktemp -d /tmp/docker-rootfs.XXXXXX)"
+TAR="$(mktemp /tmp/docker-rootfs.XXXXXX.tar)"
+docker create --name "$CID" alpine:latest
+docker export "$CID" > "$TAR"
+tar -xf "$TAR" -C "$ROOTFS"
+./build/trivy-cdxgen-local rootfs --debug --output docker-backend.cdx.json "$ROOTFS"
+docker rm -f "$CID"
+```
+
+### Scan a local rootfs directory directly
+
+```bash
+./build/trivy-cdxgen-local rootfs --output rootfs.cdx.json /tmp/rootfs
+```
 
 ## Optional enrichment knobs
 

--- a/thirdparty/trivy/main.go
+++ b/thirdparty/trivy/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/commands"
 	"github.com/aquasecurity/trivy/pkg/commands/artifact"
 	"github.com/aquasecurity/trivy/pkg/commands/operation"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/flag"
 	"github.com/aquasecurity/trivy/pkg/log"
@@ -74,9 +75,9 @@ type packageDecoration struct {
 }
 
 func main() {
-	os.Setenv("TRIVY_OFFLINE_SCAN", "true")
-	os.Setenv("TRIVY_DISABLE_TELEMETRY", "true")
-	os.Setenv("TRIVY_SKIP_VERSION_CHECK", "true")
+	_ = os.Setenv("TRIVY_OFFLINE_SCAN", "true")
+	_ = os.Setenv("TRIVY_DISABLE_TELEMETRY", "true")
+	_ = os.Setenv("TRIVY_SKIP_VERSION_CHECK", "true")
 	os.Exit(run())
 }
 
@@ -231,10 +232,11 @@ func applyCDXGenDefaults(opts *flag.Options) {
 	opts.Format = trivytypes.FormatCycloneDX
 	opts.NoProgress = true
 	opts.OfflineScan = true
-	opts.PkgTypes = []string{trivytypes.PkgTypeOS}
+	opts.PkgTypes = []string{trivytypes.PkgTypeOS, trivytypes.PkgTypeLibrary}
 	opts.Quiet = !opts.Debug
 	opts.Scanners = trivytypes.Scanners{trivytypes.SBOMScanner}
 	opts.SkipDBUpdate = true
+	opts.DisabledAnalyzers = append(opts.DisabledAnalyzers, cdxgenDisabledLanguageAnalyzers()...)
 	opts.SkipFiles = append(opts.SkipFiles,
 		"**/*.jar",
 		"**/*.war",
@@ -243,6 +245,19 @@ func applyCDXGenDefaults(opts *flag.Options) {
 	)
 	opts.SkipJavaDBUpdate = true
 	opts.SkipVersionCheck = true
+}
+
+func cdxgenDisabledLanguageAnalyzers() []analyzer.Type {
+	disabled := make([]analyzer.Type, 0, len(analyzer.TypeLanguages))
+	for _, analyzerType := range analyzer.TypeLanguages {
+		switch analyzerType {
+		case analyzer.TypeGoBinary, analyzer.TypeGoMod:
+			continue
+		default:
+			disabled = append(disabled, analyzerType)
+		}
+	}
+	return disabled
 }
 
 func runTarget(ctx context.Context, opts flag.Options, target string, targetKind artifact.TargetKind) error {
@@ -376,9 +391,9 @@ func collectPackageDecorations(results trivytypes.Results, target string, target
 				decoration.installedFiles = append(decoration.installedFiles, pkg.InstalledFiles...)
 			}
 			if opts.includeInstalledCmds {
-				paths, commands := extractInstalledCommands(rootfsTarget, pkg.InstalledFiles)
+				paths, installedCommands := extractInstalledCommands(rootfsTarget, pkg.InstalledFiles)
 				decoration.installedCommandPaths = append(decoration.installedCommandPaths, paths...)
-				decoration.installedCommands = append(decoration.installedCommands, commands...)
+				decoration.installedCommands = append(decoration.installedCommands, installedCommands...)
 			}
 			if trustDecoration, ok := trustMetadataByPackage[pkgID]; ok {
 				decoration.architecture = firstNonEmpty(trustDecoration.architecture, decoration.architecture)
@@ -414,7 +429,7 @@ func normalizePkgID(pkg ftypes.Package) string {
 
 func extractInstalledCommands(rootfsTarget string, installedFiles []string) ([]string, []string) {
 	var commandPaths []string
-	var commands []string
+	var commandNames []string
 	for _, installedFile := range uniqueSorted(installedFiles) {
 		if !looksLikeCommandPath(installedFile) {
 			continue
@@ -423,9 +438,9 @@ func extractInstalledCommands(rootfsTarget string, installedFiles []string) ([]s
 			continue
 		}
 		commandPaths = append(commandPaths, installedFile)
-		commands = append(commands, path.Base(installedFile))
+		commandNames = append(commandNames, path.Base(installedFile))
 	}
-	return uniqueSorted(commandPaths), uniqueSorted(commands)
+	return uniqueSorted(commandPaths), uniqueSorted(commandNames)
 }
 
 func looksLikeCommandPath(installedFile string) bool {

--- a/thirdparty/trivy/main_test.go
+++ b/thirdparty/trivy/main_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/aquasecurity/trivy/pkg/commands/artifact"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/flag"
 	"github.com/aquasecurity/trivy/pkg/sbom/core"
@@ -242,6 +244,9 @@ func TestParseDPKGPackageTrust(t *testing.T) {
 func TestApplyCDXGenDefaultsAddsSeparateSkipFilePatterns(t *testing.T) {
 	var opts flag.Options
 	applyCDXGenDefaults(&opts)
+	if len(opts.PkgTypes) != 2 || opts.PkgTypes[0] != trivytypes.PkgTypeOS || opts.PkgTypes[1] != trivytypes.PkgTypeLibrary {
+		t.Fatalf("unexpected package types: %#v", opts.PkgTypes)
+	}
 	want := []string{"**/*.jar", "**/*.war", "**/*.par", "**/*.ear"}
 	if len(opts.SkipFiles) != len(want) {
 		t.Fatalf("unexpected skip files: %#v", opts.SkipFiles)
@@ -250,6 +255,25 @@ func TestApplyCDXGenDefaultsAddsSeparateSkipFilePatterns(t *testing.T) {
 		if opts.SkipFiles[i] != pattern {
 			t.Fatalf("unexpected skip file pattern at index %d: %#v", i, opts.SkipFiles)
 		}
+	}
+}
+
+func TestDisabledLanguageAnalyzersRetainsOnlyGoAnalyzers(t *testing.T) {
+	disabled := cdxgenDisabledLanguageAnalyzers()
+	if slices.Contains(disabled, analyzer.TypeGoBinary) {
+		t.Fatalf("expected gobinary analyzer to remain enabled: %#v", disabled)
+	}
+	if slices.Contains(disabled, analyzer.TypeGoMod) {
+		t.Fatalf("expected gomod analyzer to remain enabled: %#v", disabled)
+	}
+	if !slices.Contains(disabled, analyzer.TypeNpmPkgLock) {
+		t.Fatalf("expected non-Go language analyzers to be disabled: %#v", disabled)
+	}
+	if !slices.Contains(disabled, analyzer.TypeJar) {
+		t.Fatalf("expected jar analyzer to stay disabled: %#v", disabled)
+	}
+	if !slices.Contains(disabled, analyzer.TypeSBOM) {
+		t.Fatalf("expected embedded sbom analyzer to stay disabled: %#v", disabled)
 	}
 }
 


### PR DESCRIPTION
Language analyzers were not set when we switched to the new wrapper in v2.1.1. The repo lacked any tests.

Related: https://github.com/cdxgen/cdxgen/issues/4121